### PR TITLE
Fix running tests on PHP 7.3 & LibXml < 2.9.10

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 Utilizamos [Versionado Semántico 2.0.0](SEMVER.md).
 
+## Cambios en la rama principal sin liberación de nueva versión.
+
+Los cambios no liberados se integran a la rama principal, pero no requieren de la liberación de una nueva versión.
+
+**2021-04-28**: Las pruebas no funcionaban correctamente con `LibXML < 2.9.10`.
+Presumiblemente por la canonicalización y recarga realizada por PHPUnit `sebastian/comparator`.
+Esto provocaba que los test no pasaran en sistemas con estas versiones, por ejemplo, Scrutinizer.
+La solución más simple fue cambiar los espacios de nombres `urn:foo` a `http://tempuri.org/foo`.
+
 ## Versión 1.0.0
 
 - Versión inicial.

--- a/tests/Features/XmlDocumentCleaners/MoveNamespaceDeclarationToRootTest.php
+++ b/tests/Features/XmlDocumentCleaners/MoveNamespaceDeclarationToRootTest.php
@@ -12,9 +12,9 @@ final class MoveNamespaceDeclarationToRootTest extends TestCase
     public function testMoveNamespaceDeclarationToRoot(): void
     {
         $document = $this->createDocument(<<<XML
-            <r:root xmlns:r="uri:root">
-              <foo:foo xmlns:foo="uri:foo"/>
-              <bar:bar xmlns:bar="uri:bar"/>
+            <r:root xmlns:r="http://tempuri.org/root">
+              <foo:foo xmlns:foo="http://tempuri.org/foo"/>
+              <bar:bar xmlns:bar="http://tempuri.org/bar"/>
               <xee/>
             </r:root>
             XML
@@ -24,7 +24,8 @@ final class MoveNamespaceDeclarationToRootTest extends TestCase
         $cleaner->clean($document);
 
         $expected = $this->createDocument(<<<XML
-            <r:root xmlns:r="uri:root" xmlns:foo="uri:foo" xmlns:bar="uri:bar">
+            <r:root xmlns:r="http://tempuri.org/root"
+              xmlns:foo="http://tempuri.org/foo" xmlns:bar="http://tempuri.org/bar">
               <foo:foo/>
               <bar:bar/>
               <xee/>

--- a/tests/Features/XmlDocumentCleaners/MoveSchemaLocationsToRootTest.php
+++ b/tests/Features/XmlDocumentCleaners/MoveSchemaLocationsToRootTest.php
@@ -15,9 +15,9 @@ final class MoveSchemaLocationsToRootTest extends TestCase
     {
         $document = $this->createDocument(<<<XML
             <root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="uri:root root.xsd uri:bar bar.xsd">
-              <foo xsi:schemaLocation="uri:foo foo.xsd">
-                <bar xsi:schemaLocation="uri:foo foo.xsd uri:bar bar.xsd"/>
+              xsi:schemaLocation="http://tempuri.org/root root.xsd http://tempuri.org/bar bar.xsd">
+              <foo xsi:schemaLocation="http://tempuri.org/foo foo.xsd">
+                <bar xsi:schemaLocation="http://tempuri.org/foo foo.xsd http://tempuri.org/bar bar.xsd"/>
               </foo>
             </root>
             XML
@@ -26,9 +26,14 @@ final class MoveSchemaLocationsToRootTest extends TestCase
         $cleaner = new MoveSchemaLocationsToRoot();
         $cleaner->clean($document);
 
+        $expectedLocations = implode(' ', [
+            'http://tempuri.org/root root.xsd',
+            'http://tempuri.org/bar bar.xsd',
+            'http://tempuri.org/foo foo.xsd',
+        ]);
         $expected = $this->createDocument(<<<XML
             <root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="uri:root root.xsd uri:bar bar.xsd uri:foo foo.xsd">
+              xsi:schemaLocation="$expectedLocations">
               <foo>
                 <bar />
               </foo>
@@ -42,8 +47,8 @@ final class MoveSchemaLocationsToRootTest extends TestCase
     {
         $document = $this->createDocument(<<<XML
             <root xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
-              xs:schemaLocation="uri:root root.xsd">
-              <foo xs:schemaLocation="uri:foo foo.xsd"/>
+              xs:schemaLocation="http://tempuri.org/root root.xsd">
+              <foo xs:schemaLocation="http://tempuri.org/foo foo.xsd"/>
             </root>
             XML
         );
@@ -53,7 +58,7 @@ final class MoveSchemaLocationsToRootTest extends TestCase
 
         $expected = $this->createDocument(<<<XML
             <root xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
-              xs:schemaLocation="uri:root root.xsd uri:foo foo.xsd">
+              xs:schemaLocation="http://tempuri.org/root root.xsd http://tempuri.org/foo foo.xsd">
               <foo/>
             </root>
             XML
@@ -65,7 +70,8 @@ final class MoveSchemaLocationsToRootTest extends TestCase
     {
         $document = $this->createDocument(<<<XML
             <root>
-              <foo xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="uri:foo foo.xsd"/>
+              <foo xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://tempuri.org/foo foo.xsd"/>
             </root>
             XML
         );
@@ -74,7 +80,8 @@ final class MoveSchemaLocationsToRootTest extends TestCase
         $cleaner->clean($document);
 
         $expected = $this->createDocument(<<<XML
-            <root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="uri:foo foo.xsd">
+            <root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://tempuri.org/foo foo.xsd">
               <foo/>
             </root>
             XML

--- a/tests/Features/XmlDocumentCleaners/RemoveNonSatNamespacesNodesTest.php
+++ b/tests/Features/XmlDocumentCleaners/RemoveNonSatNamespacesNodesTest.php
@@ -15,7 +15,7 @@ final class RemoveNonSatNamespacesNodesTest extends TestCase
     {
         $document = $this->createDocument(<<< XML
             <cfdi:Comprobante xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns:cfdi="http://www.sat.gob.mx/cfd/3" xmlns:x="url:remove:me" x:remove="me"
+            xmlns:cfdi="http://www.sat.gob.mx/cfd/3" xmlns:x="http://tempuri.org/x" x:remove="me"
             xsi:schemaLocation="http://www.sat.gob.mx/cfd/3 cfdv33.xsd"
             >
             <cfdi:Emisor Rfc="COSC8001137NA"/>
@@ -32,7 +32,7 @@ final class RemoveNonSatNamespacesNodesTest extends TestCase
 
         $expected = $this->createDocument(<<< XML
             <cfdi:Comprobante xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns:cfdi="http://www.sat.gob.mx/cfd/3" xmlns:x="url:remove:me"
+            xmlns:cfdi="http://www.sat.gob.mx/cfd/3" xmlns:x="http://tempuri.org/x"
             xsi:schemaLocation="http://www.sat.gob.mx/cfd/3 cfdv33.xsd"
             >
             <cfdi:Emisor Rfc="COSC8001137NA"/>

--- a/tests/Features/XmlDocumentCleaners/SetKnownSchemaLocationsTest.php
+++ b/tests/Features/XmlDocumentCleaners/SetKnownSchemaLocationsTest.php
@@ -72,8 +72,8 @@ final class SetKnownSchemaLocationsTest extends TestCase
     public function testSetKnownSchemaLocationsWithUnknownNamespace(): void
     {
         $document = $this->createDocument(<<<XML
-            <foo:Foo xmlns:foo="uri:foo" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="uri:foo foo.xsd" />
+            <foo:Foo xmlns:foo="http://tempuri.org/foo" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://tempuri.org/foo foo.xsd" />
             XML
         );
 
@@ -81,8 +81,8 @@ final class SetKnownSchemaLocationsTest extends TestCase
         $cleaner->clean($document);
 
         $expected = $this->createDocument(<<<XML
-            <foo:Foo xmlns:foo="uri:foo" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="uri:foo foo.xsd" />
+            <foo:Foo xmlns:foo="http://tempuri.org/foo" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://tempuri.org/foo foo.xsd" />
             XML
         );
         $this->assertEquals($expected, $document);


### PR DESCRIPTION
Las pruebas no funcionaban correctamente con `LibXML < 2.9.10`.
Presumiblemente por la canonicalización y recarga realizada por PHPUnit `sebastian/comparator`.
Esto provocaba que los test no pasaran en sistemas con estas versiones, por ejemplo, Scrutinizer.
La solución más simple fue cambiar los espacios de nombres `urn:foo` a `http://tempuri.org/foo`.