### PR TITLE
Actualizar herramientas de desarrollo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,7 +14,7 @@
 /tests/                 export-ignore
 /.gitattributes         export-ignore
 /.gitignore             export-ignore
-/.php_cs.dist           export-ignore
+/.php-cs-fixer.dist.php export-ignore
 /.scrutinizer.yml       export-ignore
 /phpcs.xml.dist         export-ignore
 /phpstan.xml.dist       export-ignore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,15 +19,16 @@ jobs:
         php-versions: ['7.3', '7.4', '8.0']
 
     steps:
-      # see https://github.com/marketplace/actions/setup-php-action
+
       - name: Checkout
         uses: actions/checkout@v2
 
+      # see https://github.com/marketplace/actions/setup-php-action
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: mbstring, json
+          extensions: dom
           coverage: none
           tools: composer:v2, cs2pr, phpcs, php-cs-fixer, phpstan
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 /tools/
 /vendor/
 /composer.lock
-.phpunit.result.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setCacheFile(__DIR__ . '/build/php_cs.cache')
     ->setRules([
@@ -12,6 +12,8 @@ return PhpCsFixer\Config::create()
         '@PHP71Migration' => true,
         '@PHP71Migration:risky' => true,
         '@PHP73Migration' => true,
+        // PHP73Migration
+        'method_argument_space' => ['on_multiline' => 'ignore'],
         // symfony
         'class_attributes_separation' => true,
         'whitespace_after_comma_in_array' => true,
@@ -19,7 +21,7 @@ return PhpCsFixer\Config::create()
         'no_extra_blank_lines' => true,
         'function_typehint_space' => true,
         'no_alias_functions' => true,
-        'trailing_comma_in_multiline_array' => true,
+        'trailing_comma_in_multiline' => ['elements' => ['arrays', 'arguments']],
         'new_with_braces' => true,
         'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,
@@ -46,6 +48,6 @@ return PhpCsFixer\Config::create()
     ->setFinder(
         PhpCsFixer\Finder::create()
             ->in(__DIR__)
-            ->exclude(['vendor', 'build'])
+            ->exclude(['vendor', 'tools', 'build'])
     )
 ;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,8 @@ Los cambios no liberados se integran a la rama principal, pero no requieren de l
 
 **2021-05-18**: Se reconfiguró el proyecto para el uso de `php-cs-fixer: ^3.0`.
 
+**2021-05-18**: Se corrigieron las extensiones usadas por la acción `build.yml/setup-php`.
+
 **2021-04-28**: Las pruebas no funcionaban correctamente con `LibXML < 2.9.10`.
 Presumiblemente por la canonicalización y recarga realizada por PHPUnit `sebastian/comparator`.
 Esto provocaba que los test no pasaran en sistemas con estas versiones, por ejemplo, Scrutinizer.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,8 @@ Los cambios no liberados se integran a la rama principal, pero no requieren de l
 
 **2021-05-18**: Se corrigieron las extensiones usadas por la acción `build.yml/setup-php`.
 
+**2021-05-18**: Se actualiza la configuración de PHPUnit con la ubicación del caché.
+
 **2021-04-28**: Las pruebas no funcionaban correctamente con `LibXML < 2.9.10`.
 Presumiblemente por la canonicalización y recarga realizada por PHPUnit `sebastian/comparator`.
 Esto provocaba que los test no pasaran en sistemas con estas versiones, por ejemplo, Scrutinizer.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,8 @@ Utilizamos [Versionado Semántico 2.0.0](SEMVER.md).
 
 Los cambios no liberados se integran a la rama principal, pero no requieren de la liberación de una nueva versión.
 
+**2021-05-18**: Se reconfiguró el proyecto para el uso de `php-cs-fixer: ^3.0`.
+
 **2021-04-28**: Las pruebas no funcionaban correctamente con `LibXML < 2.9.10`.
 Presumiblemente por la canonicalización y recarga realizada por PHPUnit `sebastian/comparator`.
 Esto provocaba que los test no pasaran en sistemas con estas versiones, por ejemplo, Scrutinizer.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,21 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-    cacheResultFile="build/phpunit.result.cache"
-    colors="true"
+    bootstrap="tests/bootstrap.php"
+    cacheResultFile="build/phpunit.cache/test-results"
+    executionOrder="depends,defects"
+    failOnRisky="true"
+    failOnWarning="true"
     verbose="true"
-    bootstrap="tests/bootstrap.php">
+    colors="true">
+
     <testsuites>
-        <testsuite name="Default">
-            <directory>./tests/</directory>
+        <testsuite name="default">
+            <directory suffix="Test.php">./tests/</directory>
         </testsuite>
     </testsuites>
-    <coverage>
+
+    <coverage cacheDirectory="build/phpunit.cache/code-coverage" processUncoveredFiles="true">
         <include>
             <directory suffix=".php">./src/</directory>
         </include>

--- a/src/XmlDocumentCleaners/MoveNamespaceDeclarationToRoot.php
+++ b/src/XmlDocumentCleaners/MoveNamespaceDeclarationToRoot.php
@@ -40,7 +40,7 @@ class MoveNamespaceDeclarationToRoot implements XmlDocumentCleanerInterface
         $rootElement->setAttributeNS(
             XmlConstants::NAMESPACE_XMLNS,
             $namespacesNode->nodeName,
-            $namespacesNode->nodeValue
+            $namespacesNode->nodeValue,
         );
 
         $this->removeNamespaceNodeAttribute($namespacesNode);

--- a/src/XmlDocumentCleaners/RemoveNonSatSchemaLocations.php
+++ b/src/XmlDocumentCleaners/RemoveNonSatSchemaLocations.php
@@ -32,7 +32,7 @@ class RemoveNonSatSchemaLocations implements XmlDocumentCleanerInterface
         $schemaLocation->filterUsingNamespace(
             function (string $namespace): bool {
                 return $this->isNamespaceRelatedToSat($namespace);
-            }
+            },
         );
         return $schemaLocation->asValue();
     }

--- a/tests/Features/XmlDocumentCleaners/RemoveAddendaTest.php
+++ b/tests/Features/XmlDocumentCleaners/RemoveAddendaTest.php
@@ -26,7 +26,7 @@ final class RemoveAddendaTest extends TestCase
         $this->assertCount(
             0,
             $document->getElementsByTagNameNS('http://www.sat.gob.mx/cfd/3', 'Addenda'),
-            'Addenda element should not exists after cleaning'
+            'Addenda element should not exists after cleaning',
         );
     }
 }


### PR DESCRIPTION
php-cs-fixer: reconfiguración a 3.0
phpunit: recolocación del cache y configuración recomendada.
gh-actions/build: setup-php con las mismas extensiones que composer.json

Este PR es de desarrollo y no requiere la liberación de una nueva versión.