### PR TITLE
Propuesta para versión 1.1.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,20 +2,19 @@
 * text=auto
 
 # Do not put this files on a distribution package (by .gitignore)
-/tools/                 export-ignore
-/vendor/                export-ignore
-/composer.lock          export-ignore
-.phpunit.result.cache   export-ignore
+/tools/                     export-ignore
+/vendor/                    export-ignore
+/composer.lock              export-ignore
 
 # Do not put this files on a distribution package
-/.github/               export-ignore
-/build/                 export-ignore
-/develop/               export-ignore
-/tests/                 export-ignore
-/.gitattributes         export-ignore
-/.gitignore             export-ignore
-/.php-cs-fixer.dist.php export-ignore
-/.scrutinizer.yml       export-ignore
-/phpcs.xml.dist         export-ignore
-/phpstan.xml.dist       export-ignore
-/phpunit.xml.dist       export-ignore
+/.github/                   export-ignore
+/build/                     export-ignore
+/develop/                   export-ignore
+/tests/                     export-ignore
+/.gitattributes             export-ignore
+/.gitignore                 export-ignore
+/.php-cs-fixer.dist.php     export-ignore
+/.scrutinizer.yml           export-ignore
+/phpcs.xml.dist             export-ignore
+/phpstan.xml.dist           export-ignore
+/phpunit.xml.dist           export-ignore

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# Código de Conducta convenido para Contribuyentes
+# Código de Conducta Convenido para Contribuyentes
 
 ## Nuestro compromiso
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ objeto documento XML no se pueda crear.
 
 Elimina todo contenido antes del primer caracter `<` y posterior al último `>`.
 
+#### `SplitXmlDeclarationFromDocument`
+
+Separa por un `LF` (`"\n"`) la declaración XML `<?xml version="1.0"?>` del cuerpo XML.
+
 #### `AppendXmlDeclaration`
 
 Agrega `<?xml version="1.0"?>` al inicio del archivo si no existe, es muy útil porque

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,26 @@ Utilizamos [Versionado Semántico 2.0.0](SEMVER.md).
 
 Los cambios no liberados se integran a la rama principal, pero no requieren de la liberación de una nueva versión.
 
+## Version 1.1.0
+
+Se agrega el limpiador de texto XML `SplitXmlDeclarationFromDocument` que separa la declaración XML del resto del
+documento XML utilizando uno y solo un caracter `LF`. Por ejemplo:
+
+```diff
+--- <?xml version="1.0"?><root />
++++ <?xml version="1.0"?>
++++ <root />
+```
+
+Además, se incluyen los siguientes cambios previamente no liberados:
+
+**2021-06-28**: Se reconfiguró PHPUnit para que fallara con un test incompleto o un *test suite* vacío,
+pasara con un test riesgoso y no fuera *verbose*. 
+
+**2021-06-28**: Se corrigió el título del código de conducta.
+
+**2021-06-28**: Se corrigió el nombre de la prueba `AddXmlDeclarationTest` a `AppendXmlDeclarationTest`.
+
 **2021-05-18**: Se reconfiguró el proyecto para el uso de `php-cs-fixer: ^3.0`.
 
 **2021-05-18**: Se corrigieron las extensiones usadas por la acción `build.yml/setup-php`.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,20 +4,20 @@
     bootstrap="tests/bootstrap.php"
     cacheResultFile="build/phpunit.cache/test-results"
     executionOrder="depends,defects"
-    failOnRisky="true"
+    failOnEmptyTestSuite="true"
+    failOnIncomplete="true"
     failOnWarning="true"
-    verbose="true"
     colors="true">
 
     <testsuites>
         <testsuite name="default">
-            <directory suffix="Test.php">./tests/</directory>
+            <directory>tests</directory>
         </testsuite>
     </testsuites>
 
     <coverage cacheDirectory="build/phpunit.cache/code-coverage" processUncoveredFiles="true">
         <include>
-            <directory suffix=".php">./src/</directory>
+            <directory suffix=".php">src</directory>
         </include>
     </coverage>
 </phpunit>

--- a/src/XmlStringCleaners.php
+++ b/src/XmlStringCleaners.php
@@ -18,6 +18,7 @@ class XmlStringCleaners implements XmlStringCleanerInterface
     {
         return new self(...[
             new XmlStringCleaners\RemoveNonXmlStrings(),
+            new XmlStringCleaners\SplitXmlDeclarationFromDocument(),
             new XmlStringCleaners\AppendXmlDeclaration(),
             new XmlStringCleaners\XmlNsSchemaLocation(),
             new XmlStringCleaners\RemoveDuplicatedCfdi3Namespace(),

--- a/src/XmlStringCleaners/SplitXmlDeclarationFromDocument.php
+++ b/src/XmlStringCleaners/SplitXmlDeclarationFromDocument.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiCleaner\XmlStringCleaners;
+
+use PhpCfdi\CfdiCleaner\XmlStringCleanerInterface;
+
+class SplitXmlDeclarationFromDocument implements XmlStringCleanerInterface
+{
+    public function clean(string $xml): string
+    {
+        return preg_replace('#(<\?xml.*?\?>)([\s]*?)<#m', "\$1\n<", $xml) ?: '';
+    }
+}

--- a/tests/Features/XmlStringCleaners/AppendXmlDeclarationTest.php
+++ b/tests/Features/XmlStringCleaners/AppendXmlDeclarationTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\CfdiCleaner\Tests\Features\XmlStringCleaners;
 use PhpCfdi\CfdiCleaner\Tests\TestCase;
 use PhpCfdi\CfdiCleaner\XmlStringCleaners\AppendXmlDeclaration;
 
-class AddXmlDeclarationTest extends TestCase
+class AppendXmlDeclarationTest extends TestCase
 {
     /** @return array<string, array{string, string}> */
     public function providerInputCases(): array

--- a/tests/Features/XmlStringCleaners/SplitXmlDeclarationFromDocumentTest.php
+++ b/tests/Features/XmlStringCleaners/SplitXmlDeclarationFromDocumentTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiCleaner\Tests\Features\XmlStringCleaners;
+
+use PhpCfdi\CfdiCleaner\Tests\TestCase;
+use PhpCfdi\CfdiCleaner\XmlStringCleaners\SplitXmlDeclarationFromDocument;
+
+final class SplitXmlDeclarationFromDocumentTest extends TestCase
+{
+    /** @return array<string, array{string, string}> */
+    public function providerInputCases(): array
+    {
+        return [
+            'doc on line 1 no white space' => [
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<root/>",
+                '<?xml version="1.0" encoding="UTF-8"?><root/>',
+            ],
+            'doc on line 1' => [
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<root/>",
+                '<?xml version="1.0" encoding="UTF-8"?> <root/>',
+            ],
+            'doc on line 2' => [
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<root/>",
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?> \n <root/>",
+            ],
+            'doc on line 3' => [
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<root/>",
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?> \n \n <root/>",
+            ],
+            'no declaration' => [
+                '<root/>',
+                '<root/>',
+            ],
+            'no encoding declaration + doc on line 2' => [
+                "<?xml version=\"1.0\"?>\n<root/>",
+                "<?xml version=\"1.0\"?> \n <root/>",
+            ],
+        ];
+    }
+
+    /**
+     * @param string $expected
+     * @param string $input
+     * @dataProvider providerInputCases
+     */
+    public function testClean(string $expected, string $input): void
+    {
+        $cleaner = new SplitXmlDeclarationFromDocument();
+        $clean = $cleaner->clean($input);
+
+        $this->assertEquals($expected, $clean);
+    }
+}


### PR DESCRIPTION
Se agrega el limpiador de texto XML `SplitXmlDeclarationFromDocument` que separa la declaración XML del resto del
documento XML utilizando uno y solo un caracter `LF`. Por ejemplo:

```diff
--- <?xml version="1.0"?><root />
+++ <?xml version="1.0"?>
+++ <root />
```
