### PR TITLE
Corregir RemoveNonXmlStrings

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,7 +8,7 @@ Utilizamos [Versionado Semántico 2.0.0](SEMVER.md).
 
 Los cambios no liberados se integran a la rama principal, pero no requieren de la liberación de una nueva versión.
 
-## Version 1.1.0
+## Versión 1.1.0
 
 Se agrega el limpiador de texto XML `SplitXmlDeclarationFromDocument` que separa la declaración XML del resto del
 documento XML utilizando uno y solo un caracter `LF`. Por ejemplo:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,14 @@ Utilizamos [Versionado Semántico 2.0.0](SEMVER.md).
 
 Los cambios no liberados se integran a la rama principal, pero no requieren de la liberación de una nueva versión.
 
+## Versión 1.1.1
+
+En algunos casos, el limpiador de cadena de caracteres `RemoveNonXmlStrings` regresaba una cadena de caracteres vacía,
+no pude determinar la causa exacta, pero fallaba con `preg_last_error_msg() == "JIT stack limit exhausted"`.
+
+Este limpiador se encarga de eliminar cualquier caracter previo al primer `<` y posterior al último `>`.
+Por lo que se ha cambiado a trabajo de cadenas de caracteres en lugar de expresiones regulares.
+
 ## Versión 1.1.0
 
 Se agrega el limpiador de texto XML `SplitXmlDeclarationFromDocument` que separa la declaración XML del resto del

--- a/src/XmlStringCleaners/RemoveNonXmlStrings.php
+++ b/src/XmlStringCleaners/RemoveNonXmlStrings.php
@@ -10,6 +10,21 @@ class RemoveNonXmlStrings implements XmlStringCleanerInterface
 {
     public function clean(string $xml): string
     {
-        return preg_replace(['/^(\s|.)*?</m', '/>(?:(.|\s)(?!>))*$/m'], ['<', '>'], $xml) ?? '';
+        $posFirstLessThan = strpos($xml, '<');
+        if (false === $posFirstLessThan) {
+            return '';
+        }
+
+        $posLastGreaterThan = strrpos($xml, '>');
+        if (false === $posLastGreaterThan) {
+            return '';
+        }
+
+        $length = $posLastGreaterThan - $posFirstLessThan + 1;
+        if ($length <= 0) {
+            return '';
+        }
+
+        return substr($xml, $posFirstLessThan, $length);
     }
 }

--- a/tests/Features/CleanerTest.php
+++ b/tests/Features/CleanerTest.php
@@ -55,4 +55,21 @@ final class CleanerTest extends TestCase
         );
         $this->assertEquals($expected, $document);
     }
+
+    /**
+     * @param string $filename
+     * @testWith ["cfdi32-real.xml"]
+     *           ["cfdi33-real.xml"]
+     */
+    public function testCleanKnownFiles(string $filename): void
+    {
+        $contents = $this->fileContents($filename);
+        $document = $this->createDocument($contents);
+
+        $cleaner = new Cleaner();
+        $cleaner->cleanDocument($document);
+        $cleanDocument = $cleaner->cleanStringToDocument($contents);
+
+        $this->assertEquals($document, $cleanDocument);
+    }
 }

--- a/tests/Features/XmlStringCleaners/RemoveNonXmlStringsTest.php
+++ b/tests/Features/XmlStringCleaners/RemoveNonXmlStringsTest.php
@@ -22,6 +22,9 @@ class RemoveNonXmlStringsTest extends TestCase
             'ltgt lead and trail' => ['<>', '_<>_'],
             'out of order string' => ['', '_>_<_'],
             'no xml' => ['< b && b >', 'a < b && b > c'],
+            'without lt or gt' => ['', 'a b c'],
+            'without gt ' => ['', 'a < b c'],
+            'without lt ' => ['', 'a b > c'],
         ];
     }
 

--- a/tests/Features/XmlStringCleaners/RemoveNonXmlStringsTest.php
+++ b/tests/Features/XmlStringCleaners/RemoveNonXmlStringsTest.php
@@ -18,6 +18,10 @@ class RemoveNonXmlStringsTest extends TestCase
             'content at begin' => ['<a></a>', 'begin<a></a>'],
             'content at end' => ['<a></a>', '<a></a>end'],
             'whitespaces and text' => ['<a></a>', "--foo\n \n\t<a></a>\n--bar\n"],
+            'ltgt empty' => ['<>', '<>'],
+            'ltgt lead and trail' => ['<>', '_<>_'],
+            'out of order string' => ['', '_>_<_'],
+            'no xml' => ['< b && b >', 'a < b && b > c'],
         ];
     }
 

--- a/tests/_files/cfdi32-real.xml
+++ b/tests/_files/cfdi32-real.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cfdi:Comprobante xmlns:cfdi="http://www.sat.gob.mx/cfd/3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sat.gob.mx/cfd/3 http://www.sat.gob.mx/sitio_internet/cfd/3/cfdv32.xsd" version="3.2" serie="S" folio="68189" fecha="2017-03-21T08:17:31" sello="NMoGn8m7nw7Z0a4zW4bCU9jsoYNazr9+EYVvAyxr0mC8fT/k50otywuMVto6dbKJqZGgYHPerHR4WPtS0G0azFdHYBE4SnEpG4au92HPOnwvOuv3fmyVAhgDo06Deoflf7D9H1vsl4E7O32WWRcfbq/8MLtH276LTs2g0mJkaWMRDYBjKjIxGLgxaxdZwJIXkxORpBiZSUs33ChqxoeCHyk0FHnZiI+H5rfBoeFdflIPMqsRQc0SbKjJHk6f8FSzxhoJKm6bLfzqroHXbIj+KQF3joAuc7EVxfIwXFxrFjvMfBPZJeafsRG2wSqb4XAVpf3v18pcCr1/YRbgmmVYiA==" formaDePago="Pago en una sola exhibicion" noCertificado="00001000000403543235" certificado="MIIGGDCCBACgAwIBAgIUMDAwMDEwMDAwMDA0MDM1NDMyMzUwDQYJKoZIhvcNAQELBQAwggGyMTgwNgYDVQQDDC9BLkMuIGRlbCBTZXJ2aWNpbyBkZSBBZG1pbmlzdHJhY2nDs24gVHJpYnV0YXJpYTEvMC0GA1UECgwmU2VydmljaW8gZGUgQWRtaW5pc3RyYWNpw7NuIFRyaWJ1dGFyaWExODA2BgNVBAsML0FkbWluaXN0cmFjacOzbiBkZSBTZWd1cmlkYWQgZGUgbGEgSW5mb3JtYWNpw7NuMR8wHQYJKoZIhvcNAQkBFhBhY29kc0BzYXQuZ29iLm14MSYwJAYDVQQJDB1Bdi4gSGlkYWxnbyA3NywgQ29sLiBHdWVycmVybzEOMAwGA1UEEQwFMDYzMDAxCzAJBgNVBAYTAk1YMRkwFwYDVQQIDBBEaXN0cml0byBGZWRlcmFsMRQwEgYDVQQHDAtDdWF1aHTDqW1vYzEVMBMGA1UELRMMU0FUOTcwNzAxTk4zMV0wWwYJKoZIhvcNAQkCDE5SZXNwb25zYWJsZTogQWRtaW5pc3RyYWNpw7NuIENlbnRyYWwgZGUgU2VydmljaW9zIFRyaWJ1dGFyaW9zIGFsIENvbnRyaWJ1eWVudGUwHhcNMTYwODMxMjI0MDMwWhcNMjAwODMxMjI0MDMwWjCBuDEeMBwGA1UEAxMVQ0VWRVIgVE9MVUNBIFNBIERFIENWMR4wHAYDVQQpExVDRVZFUiBUT0xVQ0EgU0EgREUgQ1YxHjAcBgNVBAoTFUNFVkVSIFRPTFVDQSBTQSBERSBDVjElMCMGA1UELRMcQ1RPMDIxMDA3RFo4IC8gVkVTQzQxMDUyNjFZNjEeMBwGA1UEBRMVIC8gVkVTQzQxMDUyNkhERlJOUzA4MQ8wDQYDVQQLEwZVTklEQUQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCfKhOooOKGpNrrEZGTzpI1L4aoPI1/4OnDih8qPiC2L13motAnCgVbLOxJNroHp6Zn9WJNXzuV+3ALGpInXSIjVB3up/kyKsx2ZdMFJPtXmIRVC/gMTaU4zFMB4QxpYSgPbhVVufHqKqwCrWlge4eCjD47+N6gdyNDNUtnjX2nGASkfbVepIuVTqxPhi3cx/6sujQiZnFuRgGmk1WE8/VagqJT8iR+O7sAg205vdJ6z5jgotL343Mek2MDgxJ7qf9RZTHKpXN/1QU2IsIsHjbgHnthWqY+gLC7KcUM2IRmTwhc5mjBkCiJltdj8okMOHVefK51xJUq5QfTwPbuPZgPAgMBAAGjHTAbMAwGA1UdEwEB/wQCMAAwCwYDVR0PBAQDAgbAMA0GCSqGSIb3DQEBCwUAA4ICAQAj2m2Aq1QbjKyIfVjMiJdBOzDRjNArQpwz7gtyZjLborVoaSQ4yO73CWHhU2expwy0gizMjPik2Fd6PM+5UHxgMy7OwbnDRp2V0Fzsd3TeF6sGOWfUAR11/ICcd6AgMqP40Xmhd3U54Nxqt7pbSw6/DxpbkhS9ctmYxB2EbsK9E2tFhwy1HtSm2QQhpjLTAK9JdfqRH7N/KY2tbz4kLVL7oQtvchFf/cpLPoAywkhVzMLeG+Z1ZmFxpJ5W2o+7NYEMbUN2GEHKTDgGtF/QO2uwCj157TpPH0dJ8SdSwdqHQpisWK5I9Dc8t5qDURNt4sE+5mBUkjYKg977bEX8Q9QoQMN+HxP1sGYjEMEx+MCs8Ti607da7oygvxiTR/ffQURZK8icNfGybEOC9nuzHZ1LFew+Q3eQ3wb92buut9omTx04ZXs1cWVqHWuyXcJMbDCPB64bj7LGED7K8zBl3akyQw7Ra8VtkUqkYdYlEfd21uAx2X4U0FJobhANbbUjRfSfRjnDqQbCFjpVwedMeuM1gQ3Ct8qv75N3OnGox37SYXDGakWiT5iqtdJ0QCY3fOaIFb8edD+N6+rzBS8lEoyxOkNgqBRPT15t7scCRR0ck1w3WaYVb0mpyaNNjjHhf1qaB80A79ZNadA7gB9YE0XbLymn5lXZLkrl1UvHtaK0Vg==" condicionesDePago="Credito" subTotal="4038.79" descuento="0.00" total="4685.00" metodoDePago="04" tipoDeComprobante="ingreso" Moneda="MXN" TipoCambio="1.00" LugarExpedicion="TOLUCA, ESTADO DE MEXICO" NumCtaPago="0291">
+  <cfdi:Emisor rfc="CTO021007DZ8" nombre="CEVER TOLUCA S.A. DE C.V.">
+    <cfdi:DomicilioFiscal calle="BLVD. TOLUCA-IXTAPAN NTE." noExterior="126" colonia="LA PURISIMA" localidad="METEPEC" municipio="TOLUCA" estado="ESTADO DE MEXICO" pais="Mexico" codigoPostal="52148"/>
+    <cfdi:ExpedidoEn calle="BLVD. TOLUCA-IXTAPAN NTE." noExterior="126" colonia="LA PURISIMA" localidad="METEPEC" municipio="TOLUCA" estado="ESTADO DE MEXICO" pais="Mexico" codigoPostal="52148"/>
+    <cfdi:RegimenFiscal Regimen="Regimen General de Ley Persona Moral"/>
+  </cfdi:Emisor>
+  <cfdi:Receptor rfc="XAXX010101000" nombre="CORTES SOTO CARLOS">
+    <cfdi:Domicilio calle="PRIVADA LOS CISNES, PRADERA DE LA ASUNCION" noExterior="19" colonia="LA ASUNCION" localidad="METEPEC" municipio="METEPEC" estado="MEXICO" pais="Mexico" codigoPostal="52172"/>
+  </cfdi:Receptor>
+  <cfdi:Conceptos>
+    <cfdi:Concepto cantidad="5" unidad="PIEZA" noIdentificacion="00279DRM2001" descripcion="ACEITE" valorUnitario="61.86" importe="309.30">
+</cfdi:Concepto>
+    <cfdi:Concepto cantidad="1" unidad="PIEZA" noIdentificacion="90915YZZF1" descripcion="FILTRO DE ACEITE" valorUnitario="68.48" importe="68.48">
+</cfdi:Concepto>
+    <cfdi:Concepto cantidad="1" unidad="PIEZA" noIdentificacion="17801AD010" descripcion="FILTRO DE AIRE DE MOTOR" valorUnitario="245.69" importe="245.69">
+</cfdi:Concepto>
+    <cfdi:Concepto cantidad="1" unidad="PIEZA" noIdentificacion="87139YZZ20" descripcion="FILTRO DE AIRE" valorUnitario="239.58" importe="239.58">
+</cfdi:Concepto>
+    <cfdi:Concepto cantidad="1" unidad="PIEZA" noIdentificacion="004751BF03" descripcion="LIQUIDO DE FRENOS" valorUnitario="88.11" importe="88.11">
+</cfdi:Concepto>
+    <cfdi:Concepto cantidad="1" unidad="PIEZA" noIdentificacion="MO1" descripcion="MO DE UNA HORA" valorUnitario="2837.63" importe="2837.63">
+</cfdi:Concepto>
+    <cfdi:Concepto cantidad="1" unidad="SERVICIO" noIdentificacion="TOT" descripcion="TOT MECANICA" valorUnitario="250.00" importe="250.00">
+</cfdi:Concepto>
+  </cfdi:Conceptos>
+  <cfdi:Impuestos totalImpuestosTrasladados="646.21">
+    <cfdi:Traslados>
+      <cfdi:Traslado impuesto="IVA" tasa="16" importe="646.21"/>
+    </cfdi:Traslados>
+  </cfdi:Impuestos>
+  <cfdi:Complemento>
+    <tfd:TimbreFiscalDigital xmlns:tfd="http://www.sat.gob.mx/TimbreFiscalDigital" xsi:schemaLocation="http://www.sat.gob.mx/TimbreFiscalDigital http://www.sat.gob.mx/TimbreFiscalDigital/TimbreFiscalDigital.xsd" version="1.0" UUID="80824F3B-323E-407B-8F8E-40D83FE2E69F" FechaTimbrado="2017-03-21T08:18:08" selloCFD="NMoGn8m7nw7Z0a4zW4bCU9jsoYNazr9+EYVvAyxr0mC8fT/k50otywuMVto6dbKJqZGgYHPerHR4WPtS0G0azFdHYBE4SnEpG4au92HPOnwvOuv3fmyVAhgDo06Deoflf7D9H1vsl4E7O32WWRcfbq/8MLtH276LTs2g0mJkaWMRDYBjKjIxGLgxaxdZwJIXkxORpBiZSUs33ChqxoeCHyk0FHnZiI+H5rfBoeFdflIPMqsRQc0SbKjJHk6f8FSzxhoJKm6bLfzqroHXbIj+KQF3joAuc7EVxfIwXFxrFjvMfBPZJeafsRG2wSqb4XAVpf3v18pcCr1/YRbgmmVYiA==" noCertificadoSAT="00001000000404477432" selloSAT="bQcopGo0H9dpnwKWRjZU/aKQVD4jtISYx1SRhrzHpojkTFrGcW29FimEjINvPnayNZ5Zxqp9H1fIronBNoFeeo+RxlYmBK8q6H6Gnyx80T2Dfb5Woyx8dY3FnBzjdepHg5FZuzT1Z4B/TZvyv74SK34QnyGm/NUrJCSqimdp2VRtdzvrZ+ZM2Mr7YkN35CPCylQsN+BfklFTnMtPLDVOIOwIc3w9hJqiyb4GesMTs5JZZeoAHKxB3KaYUR0HDLSs1IsULapYc87HtIuWMt5XWokWqFNSFoc+meBgQjXP6/neUJh6cT+V6uGO7rU/oZROFnDBDM2YMd2KZreXnZe4hA=="/>
+  </cfdi:Complemento>
+</cfdi:Comprobante>

--- a/tests/_files/cfdi33-real.xml
+++ b/tests/_files/cfdi33-real.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<cfdi:Comprobante xmlns:cfdi="http://www.sat.gob.mx/cfd/3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Certificado="MIIGHTCCBAWgAwIBAgIUMDAwMDEwMDAwMDA0MDEyMjA0NTEwDQYJKoZIhvcNAQELBQAwggGyMTgwNgYDVQQDDC9BLkMuIGRlbCBTZXJ2aWNpbyBkZSBBZG1pbmlzdHJhY2nDs24gVHJpYnV0YXJpYTEvMC0GA1UECgwmU2VydmljaW8gZGUgQWRtaW5pc3RyYWNpw7NuIFRyaWJ1dGFyaWExODA2BgNVBAsML0FkbWluaXN0cmFjacOzbiBkZSBTZWd1cmlkYWQgZGUgbGEgSW5mb3JtYWNpw7NuMR8wHQYJKoZIhvcNAQkBFhBhY29kc0BzYXQuZ29iLm14MSYwJAYDVQQJDB1Bdi4gSGlkYWxnbyA3NywgQ29sLiBHdWVycmVybzEOMAwGA1UEEQwFMDYzMDAxCzAJBgNVBAYTAk1YMRkwFwYDVQQIDBBEaXN0cml0byBGZWRlcmFsMRQwEgYDVQQHDAtDdWF1aHTDqW1vYzEVMBMGA1UELRMMU0FUOTcwNzAxTk4zMV0wWwYJKoZIhvcNAQkCDE5SZXNwb25zYWJsZTogQWRtaW5pc3RyYWNpw7NuIENlbnRyYWwgZGUgU2VydmljaW9zIFRyaWJ1dGFyaW9zIGFsIENvbnRyaWJ1eWVudGUwHhcNMTYwMTIwMTYwNjA5WhcNMjAwMTIwMTYwNjA5WjCBvTEgMB4GA1UEAxMXUFJPTU9UT1JBIE9USVIgU0EgREUgQ1YxIDAeBgNVBCkTF1BST01PVE9SQSBPVElSIFNBIERFIENWMSAwHgYDVQQKExdQUk9NT1RPUkEgT1RJUiBTQSBERSBDVjElMCMGA1UELRMcUE9UOTIwNzIxM0Q2IC8gT0VFSjY4MDQyMEJIMDEeMBwGA1UEBRMVIC8gT0VFSjY4MDQyMEhERlRTUzAxMQ4wDAYDVQQLEwVIT1RFTDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL2mhr0fghMamEYiMbqNpOnxn2VV4ZER6uNnL+WBa+D/G5fDQhHApO8WCim+ubrVnZO8qRw1BNhpMjsRuINIbl3uG+XVXP966CgCuy6JZ6sLAFqI3oxLHTJypW8rq12oGPtiaDfPqTH1kFtPM5AkKqE6zUt/LmWOVp34erImk9zqXD1HyDdBmmG7diAHJxH2GGfli6kbhXKPcPSvmI9Mv6cwUM7VBcUMC/j0hRLnNcxKz9HmIyJUk2F5lpdf93cTgNZl9Pf5+LgPU8J8T4/06ma6JxFgABWj2qqIsQCk8BNhivkfuWP4Mz90cdbVvthZJ3pudB0WnOjksAdKOyUvlmUCAwEAAaMdMBswDAYDVR0TAQH/BAIwADALBgNVHQ8EBAMCBsAwDQYJKoZIhvcNAQELBQADggIBADCko/5cy6b1VqckgjGuhBE/Lls1Wwu4UuU9Gr6tDxqtLUbUbris+eBqnXBQ6lzjTMhbyGVh3OFUkzI6RXk7Yi+AIrWwAPUPVx91x1fmOfm/hHY1mLEcU3t692+gzuGusC69jZaGl4HvcSxePWLMUVf/WZIWRoYdcdpWK9XJPtJvL6IvntBwaGLJA1ao2xyJweqQ3dM1HvRQ1ISdRpqIdORtHoLjpaefmXwdihx5HDpYtQYm60Yf+N8IHkm9FdreiyQLJbyERF22FZAqLtn8V5u/Tssj2BlVZO3hq7rQRd1PRaiXJooW4IXraesDi2eClwbJQ6gonjqaqAfsadwgkTNFmGlsL+YHWaNI4l2e30bj04SLGNC//Vb3vA0NVqPecZKGJiwy9/DHqBSLW6bItdfH+nAo4VUxD061cxBpSgnJzMwZR8xUbtfoxIiExp9vk+TWluCY9B486eBy0nIF6TNGT5XXRb2yJb2BYWR9AIc1awcG9wew1YKu1Ho2bdYDGmYRTZu532JaMiOjfVt+NTFXMMuSzrdkMwFYR7PbT/4VVJFMW5QtYhaMZr0QxiVjmGCLbIYBEan8MsdW7K8g0ZGwPJ6yBbbids/FV7nc1NquLKqTJPkng3vTO7cweVufU3A4QWqwR41yNTTx0QC5xeyTMl5gEQAJ2Urmx7GimAyX" CondicionesDePago="CONTADO" Fecha="2018-01-12T08:15:01" Folio="11541" FormaPago="04" LugarExpedicion="76802" MetodoPago="PUE" Moneda="MXN" NoCertificado="00001000000401220451" Sello="Xt7tK83WumikNMyx4Y/Z3R7D0rOjqTrrLu8wBlCnvXrpMFgWtyrcFUttGnevvUqCnQjuVUSpFcXqbzIQEUYNKFjxmtjwGHN+b15xUvcnfqpJRBoJe2IKd5YMZqYp9NhTJIMBYsE7+fhP1+mHcKdKn9WwXrar8uXzISqPgZ97AORBsMWmXxbVWYRtqT4MX/Xq4yhbT4jaoaut5AwhVzE1TUyZ10/C2gGySQeFVyEp9aqNScIxPotVDb7fMIWxsV26XODf6GK14B0TJNmRlCIfmfb2rQeskiYeiF5AQPb6Z2gmGLHcNks7qC+eO3EsGVr1/ntmGcwTurbGXmE4/OAgdg==" Serie="H" SubTotal="1709.12" TipoDeComprobante="I" Total="2010.01" Version="3.3" xsi:schemaLocation="http://www.sat.gob.mx/cfd/3 http://www.sat.gob.mx/sitio_internet/cfd/3/cfdv33.xsd http://www.sat.gob.mx/implocal http://www.sat.gob.mx/sitio_internet/cfd/implocal/implocal.xsd">
+  <cfdi:Emisor Nombre="PROMOTORA OTIR SA DE CV" RegimenFiscal="601" Rfc="POT9207213D6"/>
+  <cfdi:Receptor Nombre="DAY INTERNATIONAL DE MEXICO SA DE CV" Rfc="DIM8701081LA" UsoCFDI="G03"/>
+  <cfdi:Conceptos>
+    <cfdi:Concepto Cantidad="2.00" ClaveProdServ="90111501" ClaveUnidad="E48" Descripcion="Paquete" Importe="1355.67" Unidad="UNIDAD DE SERVICIO" ValorUnitario="677.83">
+      <cfdi:Impuestos>
+        <cfdi:Traslados>
+          <cfdi:Traslado Base="1355.67" Importe="216.91" Impuesto="002" TasaOCuota="0.160000" TipoFactor="Tasa"/>
+        </cfdi:Traslados>
+      </cfdi:Impuestos>
+    </cfdi:Concepto>
+    <cfdi:Concepto Cantidad="1.00" ClaveProdServ="90101501" ClaveUnidad="E48" Descripcion="Restaurante" Importe="353.45" Unidad="UNIDAD DE SERVICIO" ValorUnitario="353.45">
+      <cfdi:Impuestos>
+        <cfdi:Traslados>
+          <cfdi:Traslado Base="353.45" Importe="56.55" Impuesto="002" TasaOCuota="0.160000" TipoFactor="Tasa"/>
+        </cfdi:Traslados>
+      </cfdi:Impuestos>
+    </cfdi:Concepto>
+  </cfdi:Conceptos>
+  <cfdi:Impuestos TotalImpuestosTrasladados="273.46">
+    <cfdi:Traslados>
+      <cfdi:Traslado Importe="273.46" Impuesto="002" TasaOCuota="0.160000" TipoFactor="Tasa"/>
+    </cfdi:Traslados>
+  </cfdi:Impuestos>
+  <cfdi:Complemento>
+    <implocal:ImpuestosLocales xmlns:implocal="http://www.sat.gob.mx/implocal" TotaldeRetenciones="0.00" TotaldeTraslados="27.43" version="1.0">
+      <implocal:TrasladosLocales ImpLocTrasladado="IH" Importe="27.43" TasadeTraslado="2.50"/>
+    </implocal:ImpuestosLocales>
+    <tfd:TimbreFiscalDigital xmlns:tfd="http://www.sat.gob.mx/TimbreFiscalDigital" FechaTimbrado="2018-01-12T08:17:54" NoCertificadoSAT="00001000000406258094" RfcProvCertif="DCD090706E42" SelloCFD="Xt7tK83WumikNMyx4Y/Z3R7D0rOjqTrrLu8wBlCnvXrpMFgWtyrcFUttGnevvUqCnQjuVUSpFcXqbzIQEUYNKFjxmtjwGHN+b15xUvcnfqpJRBoJe2IKd5YMZqYp9NhTJIMBYsE7+fhP1+mHcKdKn9WwXrar8uXzISqPgZ97AORBsMWmXxbVWYRtqT4MX/Xq4yhbT4jaoaut5AwhVzE1TUyZ10/C2gGySQeFVyEp9aqNScIxPotVDb7fMIWxsV26XODf6GK14B0TJNmRlCIfmfb2rQeskiYeiF5AQPb6Z2gmGLHcNks7qC+eO3EsGVr1/ntmGcwTurbGXmE4/OAgdg==" SelloSAT="IRy7wQnKnlIsN/pSZSR7qEm/SOJuLIbNjj/S3EAd278T2uo0t73KXfXzUbbfWOwpdZEAZeosq/yEiStTaf44ZonqRS1fq6oYk12udMmT4NFrEYbPEEKLn4lqdhuW4v8ZK2Vos/pjCtYtpT+/oVIXiWg9KrGVGuMvygRPWSmd+YJq3Jm7qTz0ON0vzBOvXralSZ4Q14xUvt6ZDM9gYqIzTtCjIWaNrAdEYyqfZjvfy0uCyThh6HvCbMsX9gq4RsQj3SIoA56g+1SJevoZ6Jr722mDCLcPox3KCN75Bk8ALJI6G0weP7rQO5jEtulTRNWN3w+tlryZWElkD79MDZA6Zg==" UUID="CEE4BE01-ADFA-4DEB-8421-ADD60F0BEDAC" Version="1.1" xsi:schemaLocation="http://www.sat.gob.mx/TimbreFiscalDigital http://www.sat.gob.mx/sitio_internet/cfd/TimbreFiscalDigital/TimbreFiscalDigitalv11.xsd"/>
+  </cfdi:Complemento>
+</cfdi:Comprobante>


### PR DESCRIPTION
En algunos casos, el limpiador de cadena de caracteres `RemoveNonXmlStrings` regresaba una cadena de caracteres vacía, no pude determinar la causa exacta, pero fallaba con `preg_last_error_msg() == "JIT stack limit exhausted"`.

Este limpiador se encarga de eliminar cualquier caracter previo al primer `<` y posterior al último `>`. Por lo que se ha cambiado a trabajo de cadenas de caracteres en lugar de expresiones regulares.
