### PR TITLE
Error al iterar sobre nodos de namespace después de eliminar uno

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,18 @@ Utilizamos [Versionado Semántico 2.0.0](SEMVER.md).
 
 Los cambios no liberados se integran a la rama principal, pero no requieren de la liberación de una nueva versión.
 
+## Versión 1.1.2
+
+Se encontró un error interno en el que, después de eliminar espacios de nombres no usados, se caía en un error
+al momento de volver a iterar sobre los nodos de espacios de nombre. Lo que terminaba en una excepción.
+
+Es importante actualizar si se está observando un error parecido a este:
+
+```
+TypeError: Argument 1 passed to PhpCfdi\CfdiCleaner\XmlDocumentCleaners\MoveNamespaceDeclarationToRoot::isNamespaceReserved()
+must be of the type string, null given, called in .../vendor/phpcfdi/cfdi-cleaner/src/Internal/XmlNamespaceMethodsTrait.php on line 28
+```
+
 ## Versión 1.1.1
 
 En algunos casos, el limpiador de cadena de caracteres `RemoveNonXmlStrings` regresaba una cadena de caracteres vacía,

--- a/src/Internal/XmlNamespaceMethodsTrait.php
+++ b/src/Internal/XmlNamespaceMethodsTrait.php
@@ -25,9 +25,17 @@ trait XmlNamespaceMethodsTrait
         $xpath = new DOMXPath($document);
         $namespaceNodes = $xpath->query('//namespace::*') ?: new DOMNodeList();
         foreach ($namespaceNodes as $namespaceNode) {
-            if (! $this->isNamespaceReserved($namespaceNode->nodeValue)) {
-                yield $namespaceNode;
+            // discard removed namespaces they could be returned by XPath
+            if (null === $namespaceNode->nodeValue) {
+                continue;
             }
+
+            // discard reserved (internal xml) namespaces
+            if ($this->isNamespaceReserved($namespaceNode->nodeValue)) {
+                continue;
+            }
+
+            yield $namespaceNode;
         }
     }
 

--- a/tests/Unit/Internal/XmlNamespaceMethodsTraitTest.php
+++ b/tests/Unit/Internal/XmlNamespaceMethodsTraitTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiCleaner\Tests\Unit\Internal;
+
+use DOMDocument;
+use PhpCfdi\CfdiCleaner\Internal\XmlNamespaceMethodsTrait;
+use PhpCfdi\CfdiCleaner\Tests\TestCase;
+
+final class XmlNamespaceMethodsTraitTest extends TestCase
+{
+    public function testIterateOnRemovedNamespaces(): void
+    {
+        $specimen = new class() {
+            use XmlNamespaceMethodsTrait;
+
+            /**
+             * @param DOMDocument $document
+             * @return array<string, string>
+             */
+            public function obtainNamespaces(DOMDocument $document): array
+            {
+                $namespaces = [];
+                foreach ($this->iterateNonReservedNamespaces($document) as $namespaceNode) {
+                    $namespaces[$namespaceNode->prefix] = $namespaceNode->nodeValue;
+                }
+                asort($namespaces);
+                return $namespaces;
+            }
+
+            /**
+             * @param DOMDocument $document
+             * @param string $namespace
+             */
+            public function removeNamespaceNodesWithNamespace(DOMDocument $document, string $namespace): void
+            {
+                foreach ($this->iterateNonReservedNamespaces($document) as $namespaceNode) {
+                    if ($namespace === $namespaceNode->nodeValue) {
+                        $this->removeNamespaceNodeAttribute($namespaceNode);
+                    }
+                }
+            }
+        };
+
+        $namespaces = [
+            'root' => 'http://tempuri.org/root',
+            'unused' => 'http://tempuri.org/unused',
+            'foo' => 'http://tempuri.org/foo',
+        ];
+        asort($namespaces);
+
+        $document = $this->createDocument(<<<XML
+            <root:root xmlns:root="http://tempuri.org/root" xmlns:unused="http://tempuri.org/unused">
+              <foo:foo xmlns:foo="http://tempuri.org/foo"/>
+            </root:root>
+            XML
+        );
+
+        $this->assertSame($namespaces, $specimen->obtainNamespaces($document));
+
+        // remove unused namespace
+        $specimen->removeNamespaceNodesWithNamespace($document, 'http://tempuri.org/unused');
+        unset($namespaces['unused']);
+
+        // list of nodes should be the same
+        $this->assertSame($namespaces, $specimen->obtainNamespaces($document));
+
+        $expected = $this->createDocument(<<<XML
+            <root:root xmlns:root="http://tempuri.org/root">
+              <foo:foo xmlns:foo="http://tempuri.org/foo"/>
+            </root:root>
+            XML
+        );
+        $this->assertEquals($expected, $document);
+    }
+}


### PR DESCRIPTION
Se encontró un error interno en el que, después de eliminar espacios de nombres no usados, se caía en un error al momento de volver a iterar sobre los nodos de espacios de nombre. Lo que terminaba en una excepción.