### PR TITLE
Versión 1.1.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,9 @@
 name: build
 on:
   pull_request:
-    branches:
-      - "main"
+    branches: [ "main" ]
   push:
-    branches:
-      - "main"
+    branches: [ "main" ]
   schedule:
     - cron: '0 16 * * 0' # sunday 16:00
 
@@ -28,7 +26,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: dom
+          extensions: dom, libxml
           coverage: none
           tools: composer:v2, cs2pr, phpcs, php-cs-fixer, phpstan
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,16 @@ composer dev:test
 composer dev:build
 ```
 
+## Ejecutar GitHub Actions localmente
+
+Puedes utilizar la herramienta [`act`](https://github.com/nektos/act) para ejecutar las GitHub Actions localmente.
+Según [`actions/setup-php-action`](https://github.com/marketplace/actions/setup-php-action#local-testing-setup)
+puedes ejecutar el siguiente comando para revisar los flujos de trabajo localmente:
+
+```shell
+act -P ubuntu-latest=shivammathur/node:latest
+```
+
 [phpCfdi]:      https://github.com/phpcfdi/
 [project]:      https://github.com/phpcfdi/cfdi-cleaner
 [contributors]: https://github.com/phpcfdi/cfdi-cleaner/graphs/contributors

--- a/README.md
+++ b/README.md
@@ -152,6 +152,35 @@ Mueve todas las declaraciones de espacios de nombres al nodo raíz.
 Por lo regular el SAT pide en la documentación técnica que los espacios de nombres se definan en el nodo raíz,
 sin embargo es frecuente que se definan en el nodo que los implementa.
 
+Hay casos extremos de CFDI que siguen las reglas de XML, pero que no siguen las reglas de CFDI y generan prefijos
+que se superponen. En este caso, se moverán solamente los espacios de nombres que no se superponen, por ejemplo:
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<cfdi:Comprobante xmlns:cfdi="http://www.sat.gob.mx/cfd/3">
+  <cfdi:Complemento>
+    <cfdi:Otro xmlns:cfdi="http://www.sat.gob.mx/otro" />
+    <tfd:TimbreFiscalDigital xmlns:tfd="http://www.sat.gob.mx/TimbreFiscalDigital" />
+  </cfdi:Complemento>
+</cfdi:Comprobante>
+```
+
+Genera el siguiente resultado:
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<cfdi:Comprobante xmlns:cfdi="http://www.sat.gob.mx/cfd/3" xmlns:tfd="http://www.sat.gob.mx/TimbreFiscalDigital">
+  <cfdi:Complemento>
+    <cfdi:Otro xmlns:cfdi="http://www.sat.gob.mx/otro" />
+    <tfd:TimbreFiscalDigital />
+  </cfdi:Complemento>
+</cfdi:Comprobante>
+```
+
+Ante un caso como el anterior, no se están siguiendo las reglas establecidas en el Anexo 20 y en el complemento.
+Es mejor que siempre considere ese caso como un CFDI inválido, aun cuando se haya firmado, y solicite la
+sustitución por un CFDI que sí contenga los prefijos de los espacios de nombres correctos.
+
 #### `MoveSchemaLocationsToRoot`
 
 Mueve todas las declaraciones de ubicaciones de archivos de esquema al nodo principal.

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     "require": {
         "php": ">=7.3",
         "ext-dom": "*",
+        "ext-libxml": "*",
         "symfony/polyfill-php80": "^1.22"
     },
     "require-dev": {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,10 @@ En este caso el limpiador `MoveNamespaceDeclarationToRoot` estaba generando una 
 Se corrigió `MoveNamespaceDeclarationToRoot` para que utilice una estrategia alternativa en el caso de encontrar
 espacios de nombres con prefijos sobrepuestos y entregue una salida correcta.
 
+### `tests/clean.php`
+
+Se agregó el archivo `tests/clean.php` para limpiar un archivo CFDI y entregar la respuesta en la salida estándar.
+
 ## Versión 1.1.2
 
 Se encontró un error interno en el que, después de eliminar espacios de nombres no usados, se caía en un error

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,19 @@ Utilizamos [Versionado Semántico 2.0.0](SEMVER.md).
 
 Los cambios no liberados se integran a la rama principal, pero no requieren de la liberación de una nueva versión.
 
+## Versión 1.1.3
+
+### Error al tratar espacios de nombres predefinidos
+
+Se encontraron casos en los que el CFDI firmado por un PAC tiene severos errores de espacios de nombres XML,
+específicamente al redefinir un prefijo en uso por otro espacio de nombres. Si bien esto es correcto en XML,
+no es correcto en un CFDI.
+
+En este caso el limpiador `MoveNamespaceDeclarationToRoot` estaba generando una salida de XML no válida.
+
+Se corrigió `MoveNamespaceDeclarationToRoot` para que utilice una estrategia alternativa en el caso de encontrar
+espacios de nombres con prefijos sobrepuestos y entregue una salida correcta.
+
 ## Versión 1.1.2
 
 Se encontró un error interno en el que, después de eliminar espacios de nombres no usados, se caía en un error

--- a/src/XmlDocumentCleaners/MoveSchemaLocationsToRoot.php
+++ b/src/XmlDocumentCleaners/MoveSchemaLocationsToRoot.php
@@ -15,6 +15,7 @@ use PhpCfdi\CfdiCleaner\XmlDocumentCleanerInterface;
 class MoveSchemaLocationsToRoot implements XmlDocumentCleanerInterface
 {
     use XmlNamespaceMethodsTrait;
+
     use XmlAttributeMethodsTrait;
 
     public function clean(DOMDocument $document): void

--- a/src/XmlDocumentCleaners/RemoveNonSatNamespacesNodes.php
+++ b/src/XmlDocumentCleaners/RemoveNonSatNamespacesNodes.php
@@ -17,7 +17,9 @@ use PhpCfdi\CfdiCleaner\XmlDocumentCleanerInterface;
 class RemoveNonSatNamespacesNodes implements XmlDocumentCleanerInterface
 {
     use XmlAttributeMethodsTrait;
+
     use XmlElementMethodsTrait;
+
     use XmlNamespaceMethodsTrait;
 
     public function clean(DOMDocument $document): void

--- a/src/XmlDocumentCleaners/RemoveNonSatSchemaLocations.php
+++ b/src/XmlDocumentCleaners/RemoveNonSatSchemaLocations.php
@@ -14,6 +14,7 @@ use PhpCfdi\CfdiCleaner\XmlDocumentCleanerInterface;
 class RemoveNonSatSchemaLocations implements XmlDocumentCleanerInterface
 {
     use XmlAttributeMethodsTrait;
+
     use XmlNamespaceMethodsTrait;
 
     public function clean(DOMDocument $document): void

--- a/src/XmlDocumentCleaners/SetKnownSchemaLocations.php
+++ b/src/XmlDocumentCleaners/SetKnownSchemaLocations.php
@@ -144,6 +144,7 @@ class SetKnownSchemaLocations implements XmlDocumentCleanerInterface
     ];
 
     use XmlNamespaceMethodsTrait;
+
     use XmlAttributeMethodsTrait;
 
     public function clean(DOMDocument $document): void

--- a/tests/Features/XmlDocumentCleaners/MoveNamespaceDeclarationToRootTest.php
+++ b/tests/Features/XmlDocumentCleaners/MoveNamespaceDeclarationToRootTest.php
@@ -34,4 +34,33 @@ final class MoveNamespaceDeclarationToRootTest extends TestCase
         );
         $this->assertEquals($expected, $document);
     }
+
+    public function testMoveNamespaceDeclarationToRootWithOverlappedNamespaces(): void
+    {
+        $document = $this->createDocument(<<<XML
+            <cfdi:Comprobante xmlns:cfdi="http://www.sat.gob.mx/cfd/3">
+            <cfdi:Complemento>
+              <cfdi:Otro xmlns:cfdi="http://www.sat.gob.mx/otro" />
+              <tfd:TimbreFiscalDigital xmlns:tfd="http://www.sat.gob.mx/TimbreFiscalDigital" />
+            </cfdi:Complemento>
+            </cfdi:Comprobante>
+            XML
+        );
+
+        $cleaner = new MoveNamespaceDeclarationToRoot();
+        $cleaner->clean($document);
+
+        $expected = $this->createDocument(<<<XML
+            <cfdi:Comprobante
+            xmlns:cfdi="http://www.sat.gob.mx/cfd/3"
+            xmlns:tfd="http://www.sat.gob.mx/TimbreFiscalDigital">
+            <cfdi:Complemento>
+              <cfdi:Otro xmlns:cfdi="http://www.sat.gob.mx/otro" />
+              <tfd:TimbreFiscalDigital />
+            </cfdi:Complemento>
+            </cfdi:Comprobante>
+            XML
+        );
+        $this->assertEquals($expected, $document);
+    }
 }

--- a/tests/clean.php
+++ b/tests/clean.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpCfdi\CfdiCleaner\Cleaner;
+
+require __DIR__ . '/bootstrap.php';
+
+exit(call_user_func(function (string $command, string ...$arguments): int {
+    if (count(array_intersect($arguments, ['-h', '--help'])) > 0) {
+        echo implode(PHP_EOL, [
+            basename($command) . ' [-h|--help] cfdi.xml',
+            '  -h, --help   Show this help',
+            '  cfdi.xml     File to check',
+            '  WARNING: This program can change at any time! Do not depend on this file or its results!',
+            '',
+        ]);
+        return 0;
+    }
+    try {
+        $filename = $arguments[0];
+        if (! file_exists($filename)) {
+            throw new Exception("File $filename does not exists");
+        }
+        echo Cleaner::staticClean(file_get_contents($filename) ?: '');
+        return 0;
+    } catch (Throwable $exception) {
+        file_put_contents('php://stderr', $exception->getMessage() . PHP_EOL, FILE_APPEND);
+        return 1;
+    }
+}, ...$argv));


### PR DESCRIPTION
**Error al tratar espacios de nombres predefinidos**

Se encontraron casos en los que el CFDI firmado por un PAC tiene severos errores de espacios de nombres XML, específicamente al redefinir un prefijo en uso por otro espacio de nombres. Si bien esto es correcto en XML, no es correcto en un CFDI.

En este caso el limpiador `MoveNamespaceDeclarationToRoot` estaba generando una salida de XML no válida.

Se corrigió `MoveNamespaceDeclarationToRoot` para que utilice una estrategia alternativa en el caso de encontrar espacios de nombres con prefijos sobrepuestos y entregue una salida correcta.

**`tests/clean.php`**

Se agregó el archivo `tests/clean.php` para limpiar un archivo CFDI y entregar la respuesta en la salida estándar.