### PR TITLE
Corregir documentHasOverlappedNamespaces para entrar a moveNamespacesToRoot

### DIFF
--- a/src/Internal/XmlNamespaceMethodsTrait.php
+++ b/src/Internal/XmlNamespaceMethodsTrait.php
@@ -19,6 +19,8 @@ trait XmlNamespaceMethodsTrait
     /**
      * @param DOMDocument $document
      * @return Generator&iterable<DOMNode>
+     * @phpstan-impure
+     * @internal The actual returned class is Generator<DOMNameSpaceNode> (undocumented)
      */
     private function iterateNonReservedNamespaces(DOMDocument $document): Generator
     {

--- a/src/XmlDocumentCleaners/MoveNamespaceDeclarationToRoot.php
+++ b/src/XmlDocumentCleaners/MoveNamespaceDeclarationToRoot.php
@@ -31,7 +31,10 @@ class MoveNamespaceDeclarationToRoot implements XmlDocumentCleanerInterface
     private function documentHasOverlappedNamespaces(DOMDocument $document): bool
     {
         $prefixes = [];
+        /** $namespaceNode is a DOMNameSpaceNode, parentNode always exists */
         foreach ($this->iterateNonReservedNamespaces($document) as $namespaceNode) {
+            /** @var DOMElement $ownerElement */
+            $ownerElement = $namespaceNode->parentNode;
             /**
              * $namespaceNode->nodeName => xmlns:cfdi
              * $namespaceNode->nodeValue => http://www.sat.gob.mx/cfd/3
@@ -39,13 +42,14 @@ class MoveNamespaceDeclarationToRoot implements XmlDocumentCleanerInterface
              */
             $currentDefinition = [
                 'namespace' => $namespaceNode->nodeValue,
-                'owner' => $namespaceNode->parentNode,
+                'owner' => $ownerElement,
             ];
             if (! isset($prefixes[$namespaceNode->nodeName])) {
                 $prefixes[$namespaceNode->nodeName] = $currentDefinition;
                 continue;
             }
-            if ($prefixes[$namespaceNode->nodeName] !== $currentDefinition) {
+            if ($ownerElement->hasAttribute($namespaceNode->nodeName)
+                && $prefixes[$namespaceNode->nodeName] !== $currentDefinition) {
                 return true;
             }
         }

--- a/tests/Features/XmlDocumentCleaners/MoveNamespaceDeclarationToRootTest.php
+++ b/tests/Features/XmlDocumentCleaners/MoveNamespaceDeclarationToRootTest.php
@@ -25,7 +25,8 @@ final class MoveNamespaceDeclarationToRootTest extends TestCase
 
         $expected = $this->createDocument(<<<XML
             <r:root xmlns:r="http://tempuri.org/root"
-              xmlns:foo="http://tempuri.org/foo" xmlns:bar="http://tempuri.org/bar">
+            xmlns:foo="http://tempuri.org/foo"
+            xmlns:bar="http://tempuri.org/bar">
               <foo:foo/>
               <bar:bar/>
               <xee/>


### PR DESCRIPTION
El método `documentHasOverlappedNamespaces` no permitía entrar a `moveNamespacesToRoot`. Se asegura que solo devuelva verdadero si la definición del espacio de nombres verdaderamente existe.