### PR TITLE
Version 1.2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           fail-fast: true
       - name: Code style (phpcs)
-        run: phpcs -q --report=checkstyle src/ tests/ | cs2pr
+        run: phpcs -q --report=checkstyle | cs2pr
 
   php-cs-fixer:
     name: Code style (php-cs-fixer)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           php-version: '8.0'
           coverage: none
-          tools: composer:v2, phpstan
+          tools: composer:v2, phpstan:1.4.6
         env:
           fail-fast: true
       - name: Get composer cache directory

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           php-version: '8.0'
           coverage: none
-          tools: composer:v2, cs2pr, phpstan
+          tools: composer:v2, phpstan
         env:
           fail-fast: true
       - name: Get composer cache directory
@@ -84,7 +84,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2 # see https://github.com/marketplace/actions/setup-php-action
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
           coverage: none

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -2,6 +2,6 @@
 <phive xmlns="https://phar.io/phive">
   <phar name="phpcs" version="^3.6.2" installed="3.6.2" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.6.2" installed="3.6.2" location="./tools/phpcbf" copy="false"/>
-  <phar name="php-cs-fixer" version="^3.5.0" installed="3.5.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpstan" version="^1.4.5" installed="1.4.5" location="./tools/phpstan" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.6.0" installed="3.6.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpstan" version="^1.4.8" installed="1.4.8" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -2,6 +2,6 @@
 <phive xmlns="https://phar.io/phive">
   <phar name="phpcs" version="^3.6.2" installed="3.6.2" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.6.2" installed="3.6.2" location="./tools/phpcbf" copy="false"/>
-  <phar name="php-cs-fixer" version="^3.4.0" installed="3.4.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpstan" version="^1.3.3" installed="1.3.3" location="./tools/phpstan" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.5.0" installed="3.5.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpstan" version="^1.4.5" installed="1.4.5" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -3,5 +3,5 @@
   <phar name="phpcs" version="^3.6.2" installed="3.6.2" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.6.2" installed="3.6.2" location="./tools/phpcbf" copy="false"/>
   <phar name="php-cs-fixer" version="^3.6.0" installed="3.6.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpstan" version="^1.4.8" installed="1.4.8" location="./tools/phpstan" copy="false"/>
+  <phar name="phpstan" version="1.4.6" installed="1.4.6" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,15 +1,20 @@
 <?php
 
+/**
+ * @noinspection PhpUndefinedClassInspection
+ * @noinspection PhpUndefinedNamespaceInspection
+ * @see https://cs.symfony.com/doc/ruleSets/
+ * @see https://cs.symfony.com/doc/rules/
+ */
+
 declare(strict_types=1);
 
 return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
-    ->setCacheFile(__DIR__ . '/build/php_cs.cache')
+    ->setCacheFile(__DIR__ . '/build/php-cs-fixer.cache')
     ->setRules([
-        '@PSR2' => true,
-        '@PHP70Migration' => true,
-        '@PHP70Migration:risky' => true,
-        '@PHP71Migration' => true,
+        '@PSR12' => true,
+        '@PSR12:risky' => true,
         '@PHP71Migration:risky' => true,
         '@PHP73Migration' => true,
         // PHP73Migration
@@ -20,7 +25,6 @@ return (new PhpCsFixer\Config())
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
         'function_typehint_space' => true,
-        'no_alias_functions' => true,
         'trailing_comma_in_multiline' => ['elements' => ['arrays', 'arguments']],
         'new_with_braces' => true,
         'no_blank_lines_after_class_opening' => true,
@@ -28,7 +32,6 @@ return (new PhpCsFixer\Config())
         'object_operator_without_whitespace' => true,
         'binary_operator_spaces' => true,
         'phpdoc_scalar' => true,
-        'self_accessor' => true,
         'no_trailing_comma_in_singleline_array' => true,
         'single_quote' => true,
         'no_singleline_whitespace_before_semicolons' => true,
@@ -36,11 +39,14 @@ return (new PhpCsFixer\Config())
         'no_whitespace_in_blank_line' => true,
         'yoda_style' => ['equal' => true, 'identical' => true, 'less_and_greater' => null],
         'standardize_not_equals' => true,
-        // contrib
         'concat_space' => ['spacing' => 'one'],
+        'linebreak_after_opening_tag' => true,
+        // symfony:risky
+        'no_alias_functions' => true,
+        'self_accessor' => true,
+        // contrib
         'not_operator_with_successor_space' => true,
         'single_blank_line_before_namespace' => true,
-        'linebreak_after_opening_tag' => true,
         'blank_line_after_opening_tag' => true,
         'ordered_imports' => true,
         'array_syntax' => ['syntax' => 'short'],
@@ -48,6 +54,7 @@ return (new PhpCsFixer\Config())
     ->setFinder(
         PhpCsFixer\Finder::create()
             ->in(__DIR__)
-            ->exclude(['vendor', 'tools', 'build'])
+            ->append([__FILE__])
+            ->exclude(['vendor', 'tools', 'build']),
     )
 ;

--- a/README.md
+++ b/README.md
@@ -141,8 +141,7 @@ correspondan a la URI `http://www.sat.gob.mx/**`.
 
 #### `RemoveUnusedNamespaces`
 
-Remueve todas las declaraciones de espacios de nombres cuando no correspondan a la URI `http://www.sat.gob.mx/**`,
-por ejemplo `xmlns:foo="http://tempuri.org/foo"`.
+Remueve todas las declaraciones de espacios de nombres (junto con su prefijo) que no estén en uso.
 
 #### `RenameElementAddPrefix`
 

--- a/README.md
+++ b/README.md
@@ -110,11 +110,6 @@ las herramientas de detección de `MIME` no reconocen un archivo XML si no trae 
 Elimina un error frecuentemente encontrado en los CFDI emitidos por el SAT donde dice `xmlns:schemaLocation`
 en lugar de `xsi:schemaLocation`.
 
-#### `RemoveDuplicatedCfdi3Namespace`
-
-Elimina la declaración del espacio de nombres de CFDI 3 sin prefijo `xmlns="http://www.sat.gob.mx/cfd/3"`
-siempre y cuando también exista la declaración `xmlns:cfdi="http://www.sat.gob.mx/cfd/3"`.
-
 ### Limpiezas sobre el documento XML (`DOMDocument`)
 
 Estas limpiezas se realizan sobre el documento XML.

--- a/README.md
+++ b/README.md
@@ -144,6 +144,29 @@ correspondan a la URI `http://www.sat.gob.mx/**`.
 Remueve todas las declaraciones de espacios de nombres cuando no correspondan a la URI `http://www.sat.gob.mx/**`,
 por ejemplo `xmlns:foo="http://tempuri.org/foo"`.
 
+#### `RenameElementAddPrefix`
+
+Agrega el prefijo al nodo que no lo tiene por estar utilizando la definición simple `xmlns`.
+Además elimina los namespace superfluos y las definiciones `xmlns` redundantes.
+
+Ejemplo de CFDI sucio:
+
+```xml
+<cfdi:Comprobante xmlns="http://www.sat.gob.mx/cfd/4" xmlns:cfdi="http://www.sat.gob.mx/cfd/4">
+  <Emisor xmlns="http://www.sat.gob.mx/cfd/4" />
+  <cfdi:Receptor xmlns:cfdi="http://www.sat.gob.mx/cfd/4" />
+</cfdi:Comprobante>
+```
+
+Ejemplo de CFDI limpio:
+
+```xml
+<cfdi:Comprobante xmlns:cfdi="http://www.sat.gob.mx/cfd/4">
+  <cfdi:Emisor />
+  <cfdi:Receptor />
+</cfdi:Comprobante>
+```
+
 #### `MoveNamespaceDeclarationToRoot`
 
 Mueve todas las declaraciones de espacios de nombres al nodo raíz.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,37 @@ Los cambios no liberados se integran a la rama principal, pero no requieren de l
 
 ## UNRELEASED
 
+### Definición de XML namespace duplicado y sin prefijo
+
+Se han encontrado casos donde hay CFDI *sucios*, pero válidos, donde la definición de los nodos
+no cuenta con un prefijo. En estos casos el limpiador está produciendo un CFDI inválido después de limpiar.
+
+Para corregir este problema:
+
+- Se elimina de la lista de limpiadores de texto por defecto a `RemoveDuplicatedCfdi3Namespace`.
+- Se quita la funcionalidad de `RemoveDuplicatedCfdi3Namespace` y se emite un `E_USER_DEPRECATED`.
+- Se crea un nuevo limpiador `RenameElementAddPrefix` que agrega el prefijo al nodo que no lo tiene por estar
+  utilizando la definición simple `xmlns`. Además elimina los namespace superfluos y las 
+  definiciones `xmlns` redundantes.
+
+Ejemplo de CFDI sucio:
+
+```xml
+<cfdi:Comprobante xmlns="http://www.sat.gob.mx/cfd/4" xmlns:cfdi="http://www.sat.gob.mx/cfd/4">
+  <Emisor xmlns="http://www.sat.gob.mx/cfd/4" />
+  <cfdi:Receptor xmlns:cfdi="http://www.sat.gob.mx/cfd/4" />
+</cfdi:Comprobante>
+```
+
+Ejemplo de CFDI limpio:
+
+```xml
+<cfdi:Comprobante xmlns:cfdi="http://www.sat.gob.mx/cfd/4">
+  <cfdi:Emisor />
+  <cfdi:Receptor />
+</cfdi:Comprobante>
+```
+
 ### El limpiador `RemoveDuplicatedCfdi3Namespace` ha sido deprecado
 
 El limpiador `RemoveDuplicatedCfdi3Namespace` ha sido deprecado porque existen casos con un XML válido,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,7 +8,7 @@ Utilizamos [Versionado Semántico 2.0.0](SEMVER.md).
 
 Los cambios no liberados se integran a la rama principal, pero no requieren de la liberación de una nueva versión.
 
-## UNRELEASED
+## Versión 1.2.0
 
 ### Definición de XML namespace duplicado y sin prefijo
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,31 @@ Los cambios no liberados se integran a la rama principal, pero no requieren de l
 
 ## Versión 1.2.0
 
+### Definición de XML namespace duplicado pero sin uso
+
+Se han encontrado casos donde hay CFDI que incluyen un namespace que está en uso pero con un prefijo sin uso.
+
+En el siguiente ejemplo, el espacio de nombres `http://www.sat.gob.mx/TimbreFiscalDigital` está declarado con el
+prefijo `nsx` y `tfd`, donde el primer prefijo no está en uso y el segundo sí.
+
+```xml
+<cfdi:Comprobante xmlns:cfdi="http://www.sat.gob.mx/cfd/3"
+        xmlns:nsx="http://www.sat.gob.mx/TimbreFiscalDigital"
+        xmlns:tfd="http://www.sat.gob.mx/TimbreFiscalDigital">
+  <tfd:TimbreFiscalDigital UUID="X"/>
+</cfdi:Comprobante>
+```
+
+Se ha modificado el limpiador `RemoveUnusedNamespaces` para que cuando detecta si un espacio de nombres está
+en uso detecte también el prefijo. Con este cambio, el resultado de la limpieza sería:
+
+```xml
+<cfdi:Comprobante xmlns:cfdi="http://www.sat.gob.mx/cfd/3"
+        xmlns:tfd="http://www.sat.gob.mx/TimbreFiscalDigital">
+  <tfd:TimbreFiscalDigital UUID="X"/>
+</cfdi:Comprobante>
+```
+
 ### Definición de XML namespace duplicado y sin prefijo
 
 Se han encontrado casos donde hay CFDI *sucios*, pero válidos, donde la definición de los nodos

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,11 @@ Antes se validaba contra la propiedad `nodeValue`, pero esta propiedad puede ser
 
 Al momento de verificar si un espacio de nombres es reservado, ya no se excluye cuando el espacio de nombres es vacío.
 
+### Eliminación de definición de espacio de nombres sin prefijo
+
+Se modificó el *trait* `XmlNamespaceMethodsTrait` para que pueda eliminar un espacio de nombres sin prefijo,
+por ejemplo `xmlns="http://tempuri.org/root"` o `xmlns=""`. 
+
 ## Versión 1.1.5
 
 ### Espacios de nombres conocidos

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,28 @@ Los cambios no liberados se integran a la rama principal, pero no requieren de l
 
 ## UNRELEASED
 
+### El limpiador `RemoveDuplicatedCfdi3Namespace` ha sido deprecado
+
+El limpiador `RemoveDuplicatedCfdi3Namespace` ha sido deprecado porque existen casos con un XML válido,
+pero sucio, y el limpiador convierte el CFDI en inválido. La funcionalidad será absorvida por otro limpiador.
+
+CFDI con XML correcto, pero sucio:
+
+```xml
+<cfdi:Comprobante xmlns="http://www.sat.gob.mx/cfd/3" xmlns:cfdi="http://www.sat.gob.mx/cfd/3">
+  <Emisor xmlns="http://www.sat.gob.mx/cfd/3" />
+</cfdi:Comprobante>
+```
+
+Resultado del limpiador, donde `Emisor` ahora no pertenece al espacio de nombres `http://www.sat.gob.mx/cfd/3`.
+El XML es correcto, pero como CFDI ya no lo es:
+
+```xml
+<cfdi:Comprobante xmlns:cfdi="http://www.sat.gob.mx/cfd/3">
+  <Emisor />
+</cfdi:Comprobante>
+```
+
 ### Mejoras al manejo interno de definiciones de espacios de nombres XML
 
 Se modificó el *trait* `XmlNamespaceMethodsTrait` para que detectara si un elemento de espacios de nombres

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,16 @@ Utilizamos [Versionado Semántico 2.0.0](SEMVER.md).
 
 Los cambios no liberados se integran a la rama principal, pero no requieren de la liberación de una nueva versión.
 
+## UNRELEASED
+
+### Mejoras al manejo interno de definiciones de espacios de nombres XML
+
+Se modificó el *trait* `XmlNamespaceMethodsTrait` para que detectara si un elemento de espacios de nombres
+`DOMNameSpaceNode` está eliminado revisando si la propiedad `namespaceURI` es `NULL`.
+Antes se validaba contra la propiedad `nodeValue`, pero esta propiedad puede ser vacía, por ejemplo en `xmlns=""`.
+
+Al momento de verificar si un espacio de nombres es reservado, ya no se excluye cuando el espacio de nombres es vacío.
+
 ## Versión 1.1.5
 
 ### Espacios de nombres conocidos

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3,3 +3,8 @@
 ## Deprecaciones 2.0.0
 
 - Eliminar `PhpCfdi\CfdiCleaner\XmlStringCleaners\RemoveDuplicatedCfdi3Namespace`.
+
+## Actualizaciones
+
+- Actualizar PHPStan a una versión mayor de 1.4.6. 
+  A partir de la versión 1.4.7 parece que el tipo de objeto devuelto ya no se reconoce.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,3 +1,5 @@
 # phpcfdi/cfdi-cleaner To Do List
 
-No hay tareas pendientes.
+## Deprecaciones 2.0.0
+
+- Eliminar `PhpCfdi\CfdiCleaner\XmlStringCleaners\RemoveDuplicatedCfdi3Namespace`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -7,4 +7,4 @@
 ## Actualizaciones
 
 - Actualizar PHPStan a una versión mayor de 1.4.6. 
-  A partir de la versión 1.4.7 parece que el tipo de objeto devuelto ya no se reconoce.
+  A partir de la versión 1.4.7 parece que el tipo de `DOMNodeList<T>` no se reconoce.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,6 +4,7 @@
     bootstrap="tests/bootstrap.php"
     cacheResultFile="build/phpunit.cache/test-results"
     executionOrder="depends,defects"
+    convertDeprecationsToExceptions="true"
     failOnEmptyTestSuite="true"
     failOnIncomplete="true"
     failOnWarning="true"

--- a/src/Cleaner.php
+++ b/src/Cleaner.php
@@ -53,7 +53,7 @@ class Cleaner
         $document = new DOMDocument();
         $document->preserveWhiteSpace = false;
         $document->formatOutput = true;
-        $document->loadXML($xml);
+        $document->loadXML($xml, LIBXML_NSCLEAN | LIBXML_PARSEHUGE);
         return $document;
     }
 }

--- a/src/Internal/XmlNamespaceMethodsTrait.php
+++ b/src/Internal/XmlNamespaceMethodsTrait.php
@@ -49,7 +49,9 @@ trait XmlNamespaceMethodsTrait
         $ownerElement = $namespaceNode->parentNode;
         if ($ownerElement instanceof DOMElement) {
             $localName = ('xmlns' === $namespaceNode->localName) ? '' : $namespaceNode->localName;
-            $ownerElement->removeAttributeNS((string) $namespaceNode->nodeValue, $localName);
+            if ($ownerElement->hasAttributeNS(XmlConstants::NAMESPACE_XMLNS, $localName)) {
+                $ownerElement->removeAttributeNS((string) $namespaceNode->nodeValue, $localName);
+            }
         }
     }
 

--- a/src/Internal/XmlNamespaceMethodsTrait.php
+++ b/src/Internal/XmlNamespaceMethodsTrait.php
@@ -28,12 +28,12 @@ trait XmlNamespaceMethodsTrait
         $namespaceNodes = $xpath->query('//namespace::*') ?: new DOMNodeList();
         foreach ($namespaceNodes as $namespaceNode) {
             // discard removed namespaces they could be returned by XPath
-            if (null === $namespaceNode->nodeValue) {
+            if (null === $namespaceNode->namespaceURI) {
                 continue;
             }
 
             // discard reserved (internal xml) namespaces
-            if ($this->isNamespaceReserved($namespaceNode->nodeValue)) {
+            if ($this->isNamespaceReserved($namespaceNode->namespaceURI)) {
                 continue;
             }
 
@@ -55,7 +55,6 @@ trait XmlNamespaceMethodsTrait
     private function isNamespaceReserved(string $namespace): bool
     {
         $reservedNameSpaces = [
-            '',                             // empty
             XmlConstants::NAMESPACE_XML,    // xml
             XmlConstants::NAMESPACE_XMLNS,  // xml namespace allocation
             XmlConstants::NAMESPACE_XSI,    // xml schema instance

--- a/src/Internal/XmlNamespaceMethodsTrait.php
+++ b/src/Internal/XmlNamespaceMethodsTrait.php
@@ -48,7 +48,8 @@ trait XmlNamespaceMethodsTrait
     {
         $ownerElement = $namespaceNode->parentNode;
         if ($ownerElement instanceof DOMElement) {
-            $ownerElement->removeAttributeNS($namespaceNode->nodeValue, $namespaceNode->localName);
+            $localName = ('xmlns' === $namespaceNode->localName) ? '' : $namespaceNode->localName;
+            $ownerElement->removeAttributeNS((string) $namespaceNode->nodeValue, $localName);
         }
     }
 

--- a/src/XmlDocumentCleaners.php
+++ b/src/XmlDocumentCleaners.php
@@ -18,7 +18,7 @@ class XmlDocumentCleaners implements XmlDocumentCleanerInterface
 
     public static function createDefault(): self
     {
-        return new self(...[
+        return new self(
             new XmlDocumentCleaners\RemoveAddenda(),
             new XmlDocumentCleaners\RemoveIncompleteSchemaLocations(),
             new XmlDocumentCleaners\RemoveNonSatNamespacesNodes(),
@@ -29,7 +29,7 @@ class XmlDocumentCleaners implements XmlDocumentCleanerInterface
             new XmlDocumentCleaners\MoveSchemaLocationsToRoot(),
             new XmlDocumentCleaners\SetKnownSchemaLocations(),
             new XmlDocumentCleaners\CollapseComplemento(),
-        ]);
+        );
     }
 
     public function clean(DOMDocument $document): void

--- a/src/XmlDocumentCleaners.php
+++ b/src/XmlDocumentCleaners.php
@@ -24,6 +24,7 @@ class XmlDocumentCleaners implements XmlDocumentCleanerInterface
             new XmlDocumentCleaners\RemoveNonSatNamespacesNodes(),
             new XmlDocumentCleaners\RemoveNonSatSchemaLocations(),
             new XmlDocumentCleaners\RemoveUnusedNamespaces(),
+            new XmlDocumentCleaners\RenameElementAddPrefix(),
             new XmlDocumentCleaners\MoveNamespaceDeclarationToRoot(),
             new XmlDocumentCleaners\MoveSchemaLocationsToRoot(),
             new XmlDocumentCleaners\SetKnownSchemaLocations(),

--- a/src/XmlDocumentCleaners/RenameElementAddPrefix.php
+++ b/src/XmlDocumentCleaners/RenameElementAddPrefix.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiCleaner\XmlDocumentCleaners;
+
+use DOMDocument;
+use DOMElement;
+use PhpCfdi\CfdiCleaner\Internal\XmlNamespaceMethodsTrait;
+use PhpCfdi\CfdiCleaner\XmlDocumentCleanerInterface;
+
+final class RenameElementAddPrefix implements XmlDocumentCleanerInterface
+{
+    use XmlNamespaceMethodsTrait;
+
+    public function clean(DOMDocument $document): void
+    {
+        /** @var DOMElement|null $rootElement */
+        $rootElement = $document->documentElement;
+        if (null === $rootElement) {
+            return;
+        }
+
+        $this->cleanElement($rootElement);
+
+        // remove unused xmlns declarations
+        foreach ($this->iterateNonReservedNamespaces($document) as $namespaceNode) {
+            if ('xmlns' === $namespaceNode->nodeName) {
+                /** @var DOMElement $parentNode */
+                $parentNode = $namespaceNode->parentNode;
+                if ('' !== $this->queryPrefix($parentNode)) {
+                    $this->removeNamespaceNodeAttribute($namespaceNode);
+                }
+            }
+        }
+
+        // Remove redundant namespace declarations
+        $document->loadXML($document->saveXML() ?: '', LIBXML_NSCLEAN | LIBXML_PARSEHUGE);
+        // $document->normalizeDocument();
+    }
+
+    private function cleanElement(DOMElement $element): void
+    {
+        $this->cleanElementPrefix($element);
+
+        foreach ($element->childNodes as $child) {
+            if ($child instanceof DOMElement) {
+                $this->cleanElement($child);
+            }
+        }
+    }
+
+    private function cleanElementPrefix(DOMElement $element): void
+    {
+        $elementPrefix = (string) $element->prefix;
+        if ('' !== $elementPrefix) {
+            return;
+        }
+
+        $targetPrefix = $this->queryPrefix($element);
+        if ('' !== $targetPrefix && $elementPrefix !== $targetPrefix) {
+            $element->prefix = $targetPrefix;
+        }
+    }
+
+    private function queryPrefix(DOMElement $element): string
+    {
+        $namespace = (string) $element->namespaceURI;
+        if ('' === $namespace) {
+            return '';
+        }
+
+        /** @var DOMDocument $document */
+        $document = $element->ownerDocument;
+
+        foreach ($this->iterateNonReservedNamespaces($document) as $namespaceNode) {
+            if ($element !== $namespaceNode->parentNode) {
+                continue;
+            }
+
+            $prefix = (string) $namespaceNode->prefix;
+            if ('' !== $prefix && $namespaceNode->nodeValue === $namespace) {
+                return $prefix;
+            }
+        }
+
+        return '';
+    }
+}

--- a/src/XmlDocumentCleaners/SetKnownSchemaLocations.php
+++ b/src/XmlDocumentCleaners/SetKnownSchemaLocations.php
@@ -16,6 +16,9 @@ use PhpCfdi\CfdiCleaner\XmlDocumentCleanerInterface;
 
 class SetKnownSchemaLocations implements XmlDocumentCleanerInterface
 {
+    use XmlNamespaceMethodsTrait;
+    use XmlAttributeMethodsTrait;
+
     /**
      * List of known namespace # version xsd locations as key value map
      * @see https://github.com/phpcfdi/sat-ns-registry
@@ -152,9 +155,6 @@ class SetKnownSchemaLocations implements XmlDocumentCleanerInterface
         => 'http://www.sat.gob.mx/esquemas/retencionpago/1/'
             . 'PlataformasTecnologicas10/ServiciosPlataformasTecnologicas10.xsd',
     ];
-
-    use XmlNamespaceMethodsTrait;
-    use XmlAttributeMethodsTrait;
 
     public function clean(DOMDocument $document): void
     {

--- a/src/XmlStringCleaners.php
+++ b/src/XmlStringCleaners.php
@@ -16,13 +16,12 @@ class XmlStringCleaners implements XmlStringCleanerInterface
 
     public static function createDefault(): self
     {
-        return new self(...[
+        return new self(
             new XmlStringCleaners\RemoveNonXmlStrings(),
             new XmlStringCleaners\SplitXmlDeclarationFromDocument(),
             new XmlStringCleaners\AppendXmlDeclaration(),
             new XmlStringCleaners\XmlNsSchemaLocation(),
-            // new XmlStringCleaners\RemoveDuplicatedCfdi3Namespace(),
-        ]);
+        );
     }
 
     public function clean(string $xml): string

--- a/src/XmlStringCleaners.php
+++ b/src/XmlStringCleaners.php
@@ -21,7 +21,7 @@ class XmlStringCleaners implements XmlStringCleanerInterface
             new XmlStringCleaners\SplitXmlDeclarationFromDocument(),
             new XmlStringCleaners\AppendXmlDeclaration(),
             new XmlStringCleaners\XmlNsSchemaLocation(),
-            new XmlStringCleaners\RemoveDuplicatedCfdi3Namespace(),
+            // new XmlStringCleaners\RemoveDuplicatedCfdi3Namespace(),
         ]);
     }
 

--- a/src/XmlStringCleaners/RemoveDuplicatedCfdi3Namespace.php
+++ b/src/XmlStringCleaners/RemoveDuplicatedCfdi3Namespace.php
@@ -4,16 +4,21 @@ declare(strict_types=1);
 
 namespace PhpCfdi\CfdiCleaner\XmlStringCleaners;
 
+use PhpCfdi\CfdiCleaner\XmlDocumentCleaners\RenameElementAddPrefix;
 use PhpCfdi\CfdiCleaner\XmlStringCleanerInterface;
 
+/**
+ * @deprecated 1.2.0:2.0.0
+ * @see RenameElementAddPrefix
+ */
 class RemoveDuplicatedCfdi3Namespace implements XmlStringCleanerInterface
 {
     public function clean(string $xml): string
     {
-        if (str_contains($xml, 'xmlns="http://www.sat.gob.mx/cfd/3"')
-            && str_contains($xml, 'xmlns:cfdi="http://www.sat.gob.mx/cfd/3"')) {
-            $xml = preg_replace('#\s*xmlns="http://www.sat.gob.mx/cfd/3"\s*#', ' ', $xml) ?? '';
-        }
+        trigger_error(
+            sprintf('Class %s is deprecated, use %s', self::class, RenameElementAddPrefix::class),
+            E_USER_DEPRECATED,
+        );
         return $xml;
     }
 }

--- a/tests/Features/CleanerTest.php
+++ b/tests/Features/CleanerTest.php
@@ -18,7 +18,7 @@ final class CleanerTest extends TestCase
             <cfdi:Comprobante xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:cfdi="http://www.sat.gob.mx/cfd/3"
             xsi:schemaLocation="http://www.sat.gob.mx/cfd/3 cfdi33.xsd"
-            Version="3.3"/>        
+            Version="3.3"/>
             XML;
 
         $xmlClean = Cleaner::staticClean($xmlDirty);
@@ -39,7 +39,7 @@ final class CleanerTest extends TestCase
             <cfdi:Comprobante xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:cfdi="http://www.sat.gob.mx/cfd/3"
             xsi:schemaLocation="http://www.sat.gob.mx/cfd/3 cfdi33.xsd"
-            Version="3.3"/>        
+            Version="3.3"/>
             XML
         );
 
@@ -50,7 +50,7 @@ final class CleanerTest extends TestCase
             <cfdi:Comprobante xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:cfdi="http://www.sat.gob.mx/cfd/3"
             xsi:schemaLocation="http://www.sat.gob.mx/cfd/3 http://www.sat.gob.mx/sitio_internet/cfd/3/cfdv33.xsd"
-            Version="3.3"/>        
+            Version="3.3"/>
             XML
         );
         $this->assertEquals($expected, $document);
@@ -63,7 +63,7 @@ final class CleanerTest extends TestCase
             <cfdi:Comprobante xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:cfdi="http://www.sat.gob.mx/cfd/4"
             xsi:schemaLocation="http://www.sat.gob.mx/cfd/4 cfdi40.xsd"
-            Version="4.0"/>        
+            Version="4.0"/>
             XML;
 
         $xmlClean = Cleaner::staticClean($xmlDirty);
@@ -84,7 +84,7 @@ final class CleanerTest extends TestCase
             <cfdi:Comprobante xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:cfdi="http://www.sat.gob.mx/cfd/4"
             xsi:schemaLocation="http://www.sat.gob.mx/cfd/4 cfdi44.xsd"
-            Version="4.0"/>        
+            Version="4.0"/>
             XML
         );
 
@@ -95,7 +95,7 @@ final class CleanerTest extends TestCase
             <cfdi:Comprobante xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:cfdi="http://www.sat.gob.mx/cfd/4"
             xsi:schemaLocation="http://www.sat.gob.mx/cfd/4 http://www.sat.gob.mx/sitio_internet/cfd/4/cfdv40.xsd"
-            Version="4.0"/>        
+            Version="4.0"/>
             XML
         );
         $this->assertEquals($expected, $document);

--- a/tests/Features/XmlDocumentCleaners/RemoveNonSatNamespacesNodesTest.php
+++ b/tests/Features/XmlDocumentCleaners/RemoveNonSatNamespacesNodesTest.php
@@ -23,7 +23,7 @@ final class RemoveNonSatNamespacesNodesTest extends TestCase
               <x:remove foo="foo"/>
               <y:remove-me-too xmlns:y="lorem"/>
             </cfdi:Addenda>
-            </cfdi:Comprobante> 
+            </cfdi:Comprobante>
             XML
         );
 
@@ -37,7 +37,7 @@ final class RemoveNonSatNamespacesNodesTest extends TestCase
             >
             <cfdi:Emisor Rfc="COSC8001137NA"/>
             <cfdi:Addenda/>
-            </cfdi:Comprobante> 
+            </cfdi:Comprobante>
             XML
         );
         $this->assertEquals($expected, $document);

--- a/tests/Features/XmlDocumentCleaners/RemoveNonSatSchemaLocationsTest.php
+++ b/tests/Features/XmlDocumentCleaners/RemoveNonSatSchemaLocationsTest.php
@@ -28,7 +28,7 @@ final class RemoveNonSatSchemaLocationsTest extends TestCase
             <cfdi:Addenda>
               <foo:foo xmlns:foo="http://tempuri.org/foo" xsi:schemaLocation="http://tempuri.org/foo foo.xsd"/>
             </cfdi:Addenda>
-            </cfdi:Comprobante> 
+            </cfdi:Comprobante>
             XML
         );
 
@@ -46,7 +46,7 @@ final class RemoveNonSatSchemaLocationsTest extends TestCase
             <cfdi:Addenda>
               <foo:foo xmlns:foo="http://tempuri.org/foo"/>
             </cfdi:Addenda>
-            </cfdi:Comprobante> 
+            </cfdi:Comprobante>
             XML
         );
         $this->assertEquals($expected, $document);

--- a/tests/Features/XmlDocumentCleaners/RemoveUnusedNamespacesTest.php
+++ b/tests/Features/XmlDocumentCleaners/RemoveUnusedNamespacesTest.php
@@ -54,4 +54,30 @@ final class RemoveUnusedNamespacesTest extends TestCase
         );
         $this->assertEquals($expected, $document);
     }
+
+    public function testRemoveDuplicatedNamespacesPrefixes(): void
+    {
+        $document = $this->createDocument(<<<XML
+            <root:root
+              xmlns:wrong="http://tempuri.org/namespace"
+              xmlns:root="http://tempuri.org/root"
+              xmlns:attr="http://tempuri.org/attributes">
+              <fine:child xmlns:fine="http://tempuri.org/namespace" attr:x="y"/>
+            </root:root>
+            XML
+        );
+
+        $cleaner = new RemoveUnusedNamespaces();
+        $cleaner->clean($document);
+
+        $expected = $this->createDocument(<<<XML
+            <root:root
+              xmlns:root="http://tempuri.org/root"
+              xmlns:attr="http://tempuri.org/attributes">
+              <fine:child xmlns:fine="http://tempuri.org/namespace" attr:x="y"/>
+            </root:root>
+            XML
+        );
+        $this->assertEquals($expected, $document);
+    }
 }

--- a/tests/Features/XmlDocumentCleaners/RenameElementAddPrefixTest.php
+++ b/tests/Features/XmlDocumentCleaners/RenameElementAddPrefixTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiCleaner\Tests\Features\XmlDocumentCleaners;
+
+use PhpCfdi\CfdiCleaner\Tests\TestCase;
+use PhpCfdi\CfdiCleaner\XmlDocumentCleaners\RenameElementAddPrefix;
+
+final class RenameElementAddPrefixTest extends TestCase
+{
+    public function testRenameElementAddPrefix(): void
+    {
+        // NOTICE:
+        // - no prefix definition *before* prefixed definition on root
+        // - first element is not prefixed
+        // - second element is prefixed but contains superfluous declaration
+        // - third element is prefixed but contains unused declaration
+        $document = $this->createDocument(<<<XML
+            <r:root xmlns="http://tempuri.org/root" xmlns:r="http://tempuri.org/root" id="0">
+              <first xmlns="http://tempuri.org/root" id="1" />
+              <r:second xmlns:r="http://tempuri.org/root" id="2" />
+              <r:third xmlns="http://tempuri.org/root" id="3" />
+            </r:root>
+            XML
+        );
+
+        $cleaner = new RenameElementAddPrefix();
+        $cleaner->clean($document);
+
+        $expected = $this->createDocument(<<<XML
+            <r:root xmlns:r="http://tempuri.org/root" id="0">
+              <r:first id="1" />
+              <r:second id="2" />
+              <r:third id="3" />
+            </r:root>
+            XML
+        );
+        $this->assertEquals($expected->saveXML(), $document->saveXML());
+    }
+
+    public function testRemoveDuplicatedNamespaceAsDefault(): void
+    {
+        $document = $this->createDocument(<<<XML
+            <r:root xmlns:r="http://tempuri.org/root" xmlns="http://www.sat.gob.mx/cfd/3"/>
+            XML
+        );
+
+        $cleaner = new RenameElementAddPrefix();
+        $cleaner->clean($document);
+
+        $expected = $this->createDocument(<<<XML
+            <r:root xmlns:r="http://tempuri.org/root"/>
+            XML
+        );
+        $this->assertEquals($expected->saveXML(), $document->saveXML());
+    }
+
+    public function testRemoveEmptyNamespaceWithoutPrefix(): void
+    {
+        $document = $this->createDocument(<<<XML
+            <r:root xmlns:r="http://tempuri.org/root" xmlns=""/>
+            XML
+        );
+
+        $cleaner = new RenameElementAddPrefix();
+        $cleaner->clean($document);
+
+        $expected = $this->createDocument(<<<XML
+            <r:root xmlns:r="http://tempuri.org/root"/>
+            XML
+        );
+        $this->assertEquals($expected->saveXML(), $document->saveXML());
+    }
+}

--- a/tests/Features/XmlStringCleaners/RemoveDuplicatedCfdi3NamespaceTest.php
+++ b/tests/Features/XmlStringCleaners/RemoveDuplicatedCfdi3NamespaceTest.php
@@ -38,8 +38,9 @@ class RemoveDuplicatedCfdi3NamespaceTest extends TestCase
     public function testClean(string $expected, string $input): void
     {
         $cleaner = new RemoveDuplicatedCfdi3Namespace();
+        $this->expectDeprecation();
         $clean = $cleaner->clean($input);
 
-        $this->assertEquals($expected, $clean);
+        $this->assertEquals($input, $clean);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -23,7 +23,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         $document = new DOMDocument('1.0', 'UTF-8');
         $document->preserveWhiteSpace = false;
         $document->formatOutput = true;
-        $document->loadXML($xml);
+        $document->loadXML($xml, LIBXML_NSCLEAN | LIBXML_PARSEHUGE);
         return $document;
     }
 }

--- a/tests/Unit/Internal/XmlNamespaceMethodsTraitTest.php
+++ b/tests/Unit/Internal/XmlNamespaceMethodsTraitTest.php
@@ -13,7 +13,7 @@ final class XmlNamespaceMethodsTraitTest extends TestCase
 {
     public function testIterateOnRemovedNamespaces(): void
     {
-        $specimen = new class() {
+        $specimen = new class () {
             use XmlNamespaceMethodsTrait;
 
             /**
@@ -125,7 +125,7 @@ final class XmlNamespaceMethodsTraitTest extends TestCase
     /** @dataProvider providerRemoveNamespaceNodeAttribute */
     public function testRemoveNamespaceNodeAttribute(string $target, string $xmlInput, string $xmlExpected): void
     {
-        $specimen = new class() {
+        $specimen = new class () {
             use XmlNamespaceMethodsTrait {
                 iterateNonReservedNamespaces as public;
                 removeNamespaceNodeAttribute as public;

--- a/tests/Unit/Internal/XmlNamespaceMethodsTraitTest.php
+++ b/tests/Unit/Internal/XmlNamespaceMethodsTraitTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpCfdi\CfdiCleaner\Tests\Unit\Internal;
 
 use DOMDocument;
+use DOMElement;
 use PhpCfdi\CfdiCleaner\Internal\XmlNamespaceMethodsTrait;
 use PhpCfdi\CfdiCleaner\Tests\TestCase;
 
@@ -73,5 +74,79 @@ final class XmlNamespaceMethodsTraitTest extends TestCase
             XML
         );
         $this->assertEquals($expected, $document);
+    }
+
+    /** @return array<string, array{string, string}> */
+    public function providerRemoveNamespaceNodeAttribute(): array
+    {
+        return [
+            'unused' => [
+                'xmlns:unused',
+                <<<XML
+                    <r:root xmlns:r="http://tempuri.org/root">
+                      <r:test xmlns:unused="http://tempuri.org/root"/>
+                    </r:root>
+                    XML,
+                <<<XML
+                    <r:root xmlns:r="http://tempuri.org/root">
+                      <r:test/>
+                    </r:root>
+                    XML,
+            ],
+            'no prefix' => [
+                'xmlns',
+                <<<XML
+                    <r:root xmlns:r="http://tempuri.org/root">
+                      <r:test xmlns="http://tempuri.org/root"/>
+                    </r:root>
+                    XML,
+                <<<XML
+                    <r:root xmlns:r="http://tempuri.org/root">
+                      <r:test/>
+                    </r:root>
+                    XML,
+            ],
+            'no prefix no content' => [
+                'xmlns',
+                <<<XML
+                    <r:root xmlns:r="http://tempuri.org/root">
+                      <r:test xmlns=""/>
+                    </r:root>
+                    XML,
+                <<<XML
+                    <r:root xmlns:r="http://tempuri.org/root">
+                      <r:test/>
+                    </r:root>
+                    XML,
+            ],
+        ];
+    }
+
+    /** @dataProvider providerRemoveNamespaceNodeAttribute */
+    public function testRemoveNamespaceNodeAttribute(string $target, string $xmlInput, string $xmlExpected): void
+    {
+        $specimen = new class() {
+            use XmlNamespaceMethodsTrait {
+                iterateNonReservedNamespaces as public;
+                removeNamespaceNodeAttribute as public;
+            }
+        };
+
+        $document = $this->createDocument($xmlInput);
+
+        /** @var DOMElement $testElement */
+        $testElement = $document->getElementsByTagName('test')->item(0);
+
+        // find and remove unused "xmlns:unsused"
+        foreach ($specimen->iterateNonReservedNamespaces($document) as $namespaceNode) {
+            if ($testElement === $namespaceNode->parentNode && $target === $namespaceNode->nodeName) {
+                $specimen->removeNamespaceNodeAttribute($namespaceNode);
+            }
+        }
+
+        $expected = $this->createDocument($xmlExpected);
+
+        $this->assertEquals($expected, $document);
+        $this->assertSame($expected->saveXML(), $document->saveXML(), 'Expected XML is not identical');
     }
 }


### PR DESCRIPTION
Se quita de los limpiadores por defecto al limpiador `RemoveDuplicatedCfdi3Namespace`

Se crea un nuevo limpiador `RenameElementAddPrefix` que agrega el prefijo al nodo que no lo tiene por estar utilizando la definición simple `xmlns`. Además elimina los namespace superfluos y las definiciones `xmlns` redundantes.

Se mejoran los métodos para obtener y eliminar las definiciones de espacios de nombres

Mantenimiento en general con correcciones menores