### PR TITLE
Versión 1.2.1

### DIFF
--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -2,6 +2,6 @@
 <phive xmlns="https://phar.io/phive">
   <phar name="phpcs" version="^3.6.2" installed="3.6.2" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.6.2" installed="3.6.2" location="./tools/phpcbf" copy="false"/>
-  <phar name="php-cs-fixer" version="^3.6.0" installed="3.6.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.8.0" installed="3.8.0" location="./tools/php-cs-fixer" copy="false"/>
   <phar name="phpstan" version="1.4.6" installed="1.4.6" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -25,9 +25,6 @@ return (new PhpCsFixer\Config())
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
         'function_typehint_space' => true,
-        'trailing_comma_in_multiline' => ['elements' => ['arrays', 'arguments']],
-        'new_with_braces' => true,
-        'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,
         'binary_operator_spaces' => true,
@@ -36,7 +33,6 @@ return (new PhpCsFixer\Config())
         'single_quote' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_unused_imports' => true,
-        'no_whitespace_in_blank_line' => true,
         'yoda_style' => ['equal' => true, 'identical' => true, 'less_and_greater' => null],
         'standardize_not_equals' => true,
         'concat_space' => ['spacing' => 'one'],
@@ -46,10 +42,6 @@ return (new PhpCsFixer\Config())
         'self_accessor' => true,
         // contrib
         'not_operator_with_successor_space' => true,
-        'single_blank_line_before_namespace' => true,
-        'blank_line_after_opening_tag' => true,
-        'ordered_imports' => true,
-        'array_syntax' => ['syntax' => 'short'],
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -17,8 +17,6 @@ return (new PhpCsFixer\Config())
         '@PSR12:risky' => true,
         '@PHP71Migration:risky' => true,
         '@PHP73Migration' => true,
-        // PHP73Migration
-        'method_argument_space' => ['on_multiline' => 'ignore'],
         // symfony
         'class_attributes_separation' => true,
         'whitespace_after_comma_in_array' => true,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,16 @@ Utilizamos [Versionado Semántico 2.0.0](SEMVER.md).
 
 Los cambios no liberados se integran a la rama principal, pero no requieren de la liberación de una nueva versión.
 
+## Versión 1.2.1
+
+Se agrega la definición del espacio de nombres de *Ingresos de Hidrocarburos 1.0* a `SetKnownSchemaLocations`.
+Con esta actualización se corrige el proceso de integración continua.
+
+Se corrige el estilo de código:
+
+- Se modifican los textos HEREDOC usados como argumentos de funciones.
+- Se actualiza `php-cs-fixer` de `3.6.0` a `3.8.0`.
+
 ## Versión 1.2.0
 
 ### Definición de XML namespace duplicado pero sin uso

--- a/src/XmlDocumentCleaners/SetKnownSchemaLocations.php
+++ b/src/XmlDocumentCleaners/SetKnownSchemaLocations.php
@@ -115,6 +115,8 @@ class SetKnownSchemaLocations implements XmlDocumentCleanerInterface
         => 'http://www.sat.gob.mx/sitio_internet/cfd/Pagos/Pagos20.xsd',
         'http://www.sat.gob.mx/GastosHidrocarburos10#1.0'
         => 'http://www.sat.gob.mx/sitio_internet/cfd/GastosHidrocarburos10/GastosHidrocarburos10.xsd',
+        'http://www.sat.gob.mx/IngresosHidrocarburos10#1.0'
+        => 'http://www.sat.gob.mx/sitio_internet/cfd/IngresosHidrocarburos10/IngresosHidrocarburos.xsd',
         'http://www.sat.gob.mx/iedu#1.0'
         => 'http://www.sat.gob.mx/sitio_internet/cfd/iedu/iedu.xsd',
         'http://www.sat.gob.mx/ventavehiculos#1.1'

--- a/tests/Features/CleanerTest.php
+++ b/tests/Features/CleanerTest.php
@@ -40,8 +40,7 @@ final class CleanerTest extends TestCase
             xmlns:cfdi="http://www.sat.gob.mx/cfd/3"
             xsi:schemaLocation="http://www.sat.gob.mx/cfd/3 cfdi33.xsd"
             Version="3.3"/>
-            XML
-        );
+            XML);
 
         $cleaner = new Cleaner();
         $cleaner->cleanDocument($document);
@@ -51,8 +50,7 @@ final class CleanerTest extends TestCase
             xmlns:cfdi="http://www.sat.gob.mx/cfd/3"
             xsi:schemaLocation="http://www.sat.gob.mx/cfd/3 http://www.sat.gob.mx/sitio_internet/cfd/3/cfdv33.xsd"
             Version="3.3"/>
-            XML
-        );
+            XML);
         $this->assertEquals($expected, $document);
     }
 
@@ -85,8 +83,7 @@ final class CleanerTest extends TestCase
             xmlns:cfdi="http://www.sat.gob.mx/cfd/4"
             xsi:schemaLocation="http://www.sat.gob.mx/cfd/4 cfdi44.xsd"
             Version="4.0"/>
-            XML
-        );
+            XML);
 
         $cleaner = new Cleaner();
         $cleaner->cleanDocument($document);
@@ -96,8 +93,7 @@ final class CleanerTest extends TestCase
             xmlns:cfdi="http://www.sat.gob.mx/cfd/4"
             xsi:schemaLocation="http://www.sat.gob.mx/cfd/4 http://www.sat.gob.mx/sitio_internet/cfd/4/cfdv40.xsd"
             Version="4.0"/>
-            XML
-        );
+            XML);
         $this->assertEquals($expected, $document);
     }
 

--- a/tests/Features/XmlDocumentCleaners/CollapseComplementoTest.php
+++ b/tests/Features/XmlDocumentCleaners/CollapseComplementoTest.php
@@ -11,7 +11,7 @@ class CollapseComplementoTest extends TestCase
 {
     public function testCleanNonCfdiNotAlterDocument(): void
     {
-        $document = $this->createDocument(<<< XML
+        $document = $this->createDocument(<<<XML
             <cfdi:Comprobante xmlns:cfdi="http://tempuri.org/cfd">
               <cfdi:Complemento>
                 <foo:Foo id="first" xmlns:foo="http://tempuri.org/foo">
@@ -24,8 +24,7 @@ class CollapseComplementoTest extends TestCase
                 </foo:Foo>
               </cfdi:Complemento>
             </cfdi:Comprobante>
-            XML
-        );
+            XML);
         /** @var string $xmlBeforeClean */
         $xmlBeforeClean = $document->saveXML();
 
@@ -37,7 +36,7 @@ class CollapseComplementoTest extends TestCase
 
     public function testCleanCfdiWithJustOneComplemento(): void
     {
-        $document = $this->createDocument(<<< XML
+        $document = $this->createDocument(<<<XML
             <cfdi:Comprobante xmlns:cfdi="http://www.sat.gob.mx/cfd/3">
               <cfdi:Complemento>
                 <foo:Foo id="first" xmlns:foo="http://tempuri.org/foo">
@@ -48,8 +47,7 @@ class CollapseComplementoTest extends TestCase
                 </foo:Foo>
               </cfdi:Complemento>
             </cfdi:Comprobante>
-            XML
-        );
+            XML);
         /** @var string $xmlBeforeClean */
         $xmlBeforeClean = $document->saveXML();
 
@@ -61,7 +59,7 @@ class CollapseComplementoTest extends TestCase
 
     public function testCleanCfdiWithThreeComplementos(): void
     {
-        $document = $this->createDocument(<<< XML
+        $document = $this->createDocument(<<<XML
             <cfdi:Comprobante xmlns:cfdi="http://www.sat.gob.mx/cfd/3">
               <cfdi:Complemento>
                 <foo:Foo id="first" xmlns:foo="http://tempuri.org/foo">
@@ -81,10 +79,9 @@ class CollapseComplementoTest extends TestCase
                 </foo:Foo>
               </cfdi:Complemento>
             </cfdi:Comprobante>
-            XML
-        );
+            XML);
 
-        $expected = $this->createDocument(<<< XML
+        $expected = $this->createDocument(<<<XML
             <cfdi:Comprobante xmlns:cfdi="http://www.sat.gob.mx/cfd/3">
               <cfdi:Complemento>
                 <foo:Foo id="first" xmlns:foo="http://tempuri.org/foo">
@@ -98,8 +95,7 @@ class CollapseComplementoTest extends TestCase
                 </foo:Foo>
               </cfdi:Complemento>
             </cfdi:Comprobante>
-            XML
-        );
+            XML);
 
         $cleaner = new CollapseComplemento();
         $cleaner->clean($document);

--- a/tests/Features/XmlDocumentCleaners/MoveNamespaceDeclarationToRootTest.php
+++ b/tests/Features/XmlDocumentCleaners/MoveNamespaceDeclarationToRootTest.php
@@ -17,8 +17,7 @@ final class MoveNamespaceDeclarationToRootTest extends TestCase
               <bar:bar xmlns:bar="http://tempuri.org/bar"/>
               <xee/>
             </r:root>
-            XML
-        );
+            XML);
 
         $cleaner = new MoveNamespaceDeclarationToRoot();
         $cleaner->clean($document);
@@ -31,8 +30,7 @@ final class MoveNamespaceDeclarationToRootTest extends TestCase
               <bar:bar/>
               <xee/>
             </r:root>
-            XML
-        );
+            XML);
         $this->assertEquals($expected, $document);
     }
 
@@ -45,8 +43,7 @@ final class MoveNamespaceDeclarationToRootTest extends TestCase
               <tfd:TimbreFiscalDigital xmlns:tfd="http://www.sat.gob.mx/TimbreFiscalDigital" />
             </cfdi:Complemento>
             </cfdi:Comprobante>
-            XML
-        );
+            XML);
 
         $cleaner = new MoveNamespaceDeclarationToRoot();
         $cleaner->clean($document);
@@ -60,8 +57,7 @@ final class MoveNamespaceDeclarationToRootTest extends TestCase
               <tfd:TimbreFiscalDigital />
             </cfdi:Complemento>
             </cfdi:Comprobante>
-            XML
-        );
+            XML);
         $this->assertEquals($expected, $document);
     }
 
@@ -74,8 +70,7 @@ final class MoveNamespaceDeclarationToRootTest extends TestCase
                 <tfd:TimbreFiscalDigital xmlns:tfd="http://www.sat.gob.mx/TimbreFiscalDigital" />
               </cfdi:Complemento>
             </cfdi:Comprobante>
-            XML
-        );
+            XML);
 
         $cleaner = new MoveNamespaceDeclarationToRoot();
         $cleaner->clean($document);
@@ -90,8 +85,7 @@ final class MoveNamespaceDeclarationToRootTest extends TestCase
                 <tfd:TimbreFiscalDigital />
               </cfdi:Complemento>
             </cfdi:Comprobante>
-            XML
-        );
+            XML);
         $this->assertEquals($expected, $document);
     }
 }

--- a/tests/Features/XmlDocumentCleaners/MoveSchemaLocationsToRootTest.php
+++ b/tests/Features/XmlDocumentCleaners/MoveSchemaLocationsToRootTest.php
@@ -20,8 +20,7 @@ final class MoveSchemaLocationsToRootTest extends TestCase
                 <bar xsi:schemaLocation="http://tempuri.org/foo foo.xsd http://tempuri.org/bar bar.xsd"/>
               </foo>
             </root>
-            XML
-        );
+            XML);
 
         $cleaner = new MoveSchemaLocationsToRoot();
         $cleaner->clean($document);
@@ -38,8 +37,7 @@ final class MoveSchemaLocationsToRootTest extends TestCase
                 <bar />
               </foo>
             </root>
-            XML
-        );
+            XML);
         $this->assertEquals($expected, $document);
     }
 
@@ -50,8 +48,7 @@ final class MoveSchemaLocationsToRootTest extends TestCase
               xs:schemaLocation="http://tempuri.org/root root.xsd">
               <foo xs:schemaLocation="http://tempuri.org/foo foo.xsd"/>
             </root>
-            XML
-        );
+            XML);
 
         $cleaner = new MoveSchemaLocationsToRoot();
         $cleaner->clean($document);
@@ -61,8 +58,7 @@ final class MoveSchemaLocationsToRootTest extends TestCase
               xs:schemaLocation="http://tempuri.org/root root.xsd http://tempuri.org/foo foo.xsd">
               <foo/>
             </root>
-            XML
-        );
+            XML);
         $this->assertEquals($expected, $document);
     }
 
@@ -73,8 +69,7 @@ final class MoveSchemaLocationsToRootTest extends TestCase
               <foo xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 xsi:schemaLocation="http://tempuri.org/foo foo.xsd"/>
             </root>
-            XML
-        );
+            XML);
 
         $cleaner = new MoveSchemaLocationsToRoot();
         $cleaner->clean($document);
@@ -84,8 +79,7 @@ final class MoveSchemaLocationsToRootTest extends TestCase
               xsi:schemaLocation="http://tempuri.org/foo foo.xsd">
               <foo/>
             </root>
-            XML
-        );
+            XML);
         $this->assertEquals($expected, $document);
     }
 }

--- a/tests/Features/XmlDocumentCleaners/RemoveAddendaTest.php
+++ b/tests/Features/XmlDocumentCleaners/RemoveAddendaTest.php
@@ -11,14 +11,13 @@ final class RemoveAddendaTest extends TestCase
 {
     public function testCleanDocumentWithAddenda(): void
     {
-        $document = $this->createDocument(<<< XML
+        $document = $this->createDocument(<<<XML
             <x:Comprobante xmlns:x="http://www.sat.gob.mx/cfd/3">
             <x:Addenda>
                 <o:OtherData xmlns:o="http://tempuri.org/other" foo="bar" />
             </x:Addenda>
             </x:Comprobante>
-            XML
-        );
+            XML);
 
         $cleaner = new RemoveAddenda();
         $cleaner->clean($document);

--- a/tests/Features/XmlDocumentCleaners/RemoveIncompleteSchemaLocationsTest.php
+++ b/tests/Features/XmlDocumentCleaners/RemoveIncompleteSchemaLocationsTest.php
@@ -14,18 +14,16 @@ class RemoveIncompleteSchemaLocationsTest extends TestCase
     public function testCleanSchemaLocationsWithIncompletePairsOnlyOnRoot(): void
     {
         // content has incomplete schema location "foo"
-        $document = $this->createDocument(<<< XML
+        $document = $this->createDocument(<<<XML
             <r xmlns="http://tempuri.org/r" xmlns:x="http://www.w3.org/2001/XMLSchema-instance"
             x:schemaLocation="http://tempuri.org/r r.xsd http://tempuri.org/foo http://tempuri.org/bar bar.xsd"
             />
-            XML
-        );
-        $expected = $this->createDocument(<<< XML
+            XML);
+        $expected = $this->createDocument(<<<XML
             <r xmlns="http://tempuri.org/r" xmlns:x="http://www.w3.org/2001/XMLSchema-instance"
             x:schemaLocation="http://tempuri.org/r r.xsd http://tempuri.org/bar bar.xsd"
             />
-            XML
-        );
+            XML);
 
         $cleaner = new RemoveIncompleteSchemaLocations();
         $cleaner->clean($document);
@@ -36,7 +34,7 @@ class RemoveIncompleteSchemaLocationsTest extends TestCase
     public function testCleanSchemaLocationsWithIncompletePairsOnlyOnChildren(): void
     {
         // content has incomplete schema location "foo"
-        $document = $this->createDocument(<<< XML
+        $document = $this->createDocument(<<<XML
             <root>
             <child xmlns="http://tempuri.org/r" xmlns:x="http://www.w3.org/2001/XMLSchema-instance"
             x:schemaLocation="
@@ -47,15 +45,13 @@ class RemoveIncompleteSchemaLocationsTest extends TestCase
              http://tempuri.org/remove-ns      http://tempuri.org/remove-non-xsd  "
              />
             </root>
-            XML
-        );
-        $expected = $this->createDocument(<<< XML
+            XML);
+        $expected = $this->createDocument(<<<XML
             <root>
             <child xmlns="http://tempuri.org/r" xmlns:x="http://www.w3.org/2001/XMLSchema-instance"
             x:schemaLocation="http://tempuri.org/foo foo.xsd http://tempuri.org/bar bar.xsd"/>
             </root>
-            XML
-        );
+            XML);
 
         $cleaner = new RemoveIncompleteSchemaLocations();
         $cleaner->clean($document);

--- a/tests/Features/XmlDocumentCleaners/RemoveNonSatNamespacesNodesTest.php
+++ b/tests/Features/XmlDocumentCleaners/RemoveNonSatNamespacesNodesTest.php
@@ -13,7 +13,7 @@ final class RemoveNonSatNamespacesNodesTest extends TestCase
 {
     public function testClean(): void
     {
-        $document = $this->createDocument(<<< XML
+        $document = $this->createDocument(<<<XML
             <cfdi:Comprobante xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:cfdi="http://www.sat.gob.mx/cfd/3" xmlns:x="http://tempuri.org/x" x:remove="me"
             xsi:schemaLocation="http://www.sat.gob.mx/cfd/3 cfdv33.xsd"
@@ -24,13 +24,12 @@ final class RemoveNonSatNamespacesNodesTest extends TestCase
               <y:remove-me-too xmlns:y="lorem"/>
             </cfdi:Addenda>
             </cfdi:Comprobante>
-            XML
-        );
+            XML);
 
         $cleaner = new RemoveNonSatNamespacesNodes();
         $cleaner->clean($document);
 
-        $expected = $this->createDocument(<<< XML
+        $expected = $this->createDocument(<<<XML
             <cfdi:Comprobante xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:cfdi="http://www.sat.gob.mx/cfd/3" xmlns:x="http://tempuri.org/x"
             xsi:schemaLocation="http://www.sat.gob.mx/cfd/3 cfdv33.xsd"
@@ -38,8 +37,7 @@ final class RemoveNonSatNamespacesNodesTest extends TestCase
             <cfdi:Emisor Rfc="COSC8001137NA"/>
             <cfdi:Addenda/>
             </cfdi:Comprobante>
-            XML
-        );
+            XML);
         $this->assertEquals($expected, $document);
     }
 }

--- a/tests/Features/XmlDocumentCleaners/RemoveNonSatSchemaLocationsTest.php
+++ b/tests/Features/XmlDocumentCleaners/RemoveNonSatSchemaLocationsTest.php
@@ -13,7 +13,7 @@ final class RemoveNonSatSchemaLocationsTest extends TestCase
 {
     public function testClean(): void
     {
-        $document = $this->createDocument(<<< XML
+        $document = $this->createDocument(<<<XML
             <cfdi:Comprobante xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:cfdi="http://www.sat.gob.mx/cfd/3"
             xmlns:extra="http://www.sat.gob.mx/extra"
@@ -29,13 +29,12 @@ final class RemoveNonSatSchemaLocationsTest extends TestCase
               <foo:foo xmlns:foo="http://tempuri.org/foo" xsi:schemaLocation="http://tempuri.org/foo foo.xsd"/>
             </cfdi:Addenda>
             </cfdi:Comprobante>
-            XML
-        );
+            XML);
 
         $cleaner = new RemoveNonSatSchemaLocations();
         $cleaner->clean($document);
 
-        $expected = $this->createDocument(<<< XML
+        $expected = $this->createDocument(<<<XML
             <cfdi:Comprobante xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:cfdi="http://www.sat.gob.mx/cfd/3"
             xmlns:extra="http://www.sat.gob.mx/extra"
@@ -47,8 +46,7 @@ final class RemoveNonSatSchemaLocationsTest extends TestCase
               <foo:foo xmlns:foo="http://tempuri.org/foo"/>
             </cfdi:Addenda>
             </cfdi:Comprobante>
-            XML
-        );
+            XML);
         $this->assertEquals($expected, $document);
     }
 }

--- a/tests/Features/XmlDocumentCleaners/RemoveUnusedNamespacesTest.php
+++ b/tests/Features/XmlDocumentCleaners/RemoveUnusedNamespacesTest.php
@@ -17,16 +17,14 @@ final class RemoveUnusedNamespacesTest extends TestCase
               xmlns:r="http://tempuri.org/root"
               xmlns:f="http://tempuri.org/foo"
             />
-            XML
-        );
+            XML);
 
         $cleaner = new RemoveUnusedNamespaces();
         $cleaner->clean($document);
 
         $expected = $this->createDocument(<<<XML
             <r:root xmlns:r="http://tempuri.org/root"/>
-            XML
-        );
+            XML);
         $this->assertEquals($expected, $document);
     }
 
@@ -38,8 +36,7 @@ final class RemoveUnusedNamespacesTest extends TestCase
                 <a:child xmlns:xee="http://tempuri.org/xee" f:foo="foo"/>
               </a:child>
             </r:root>
-            XML
-        );
+            XML);
 
         $cleaner = new RemoveUnusedNamespaces();
         $cleaner->clean($document);
@@ -50,8 +47,7 @@ final class RemoveUnusedNamespacesTest extends TestCase
                 <a:child f:foo="foo"/>
               </a:child>
             </r:root>
-            XML
-        );
+            XML);
         $this->assertEquals($expected, $document);
     }
 
@@ -64,8 +60,7 @@ final class RemoveUnusedNamespacesTest extends TestCase
               xmlns:attr="http://tempuri.org/attributes">
               <fine:child xmlns:fine="http://tempuri.org/namespace" attr:x="y"/>
             </root:root>
-            XML
-        );
+            XML);
 
         $cleaner = new RemoveUnusedNamespaces();
         $cleaner->clean($document);
@@ -76,8 +71,7 @@ final class RemoveUnusedNamespacesTest extends TestCase
               xmlns:attr="http://tempuri.org/attributes">
               <fine:child xmlns:fine="http://tempuri.org/namespace" attr:x="y"/>
             </root:root>
-            XML
-        );
+            XML);
         $this->assertEquals($expected, $document);
     }
 }

--- a/tests/Features/XmlDocumentCleaners/RenameElementAddPrefixTest.php
+++ b/tests/Features/XmlDocumentCleaners/RenameElementAddPrefixTest.php
@@ -22,8 +22,7 @@ final class RenameElementAddPrefixTest extends TestCase
               <r:second xmlns:r="http://tempuri.org/root" id="2" />
               <r:third xmlns="http://tempuri.org/root" id="3" />
             </r:root>
-            XML
-        );
+            XML);
 
         $cleaner = new RenameElementAddPrefix();
         $cleaner->clean($document);
@@ -34,8 +33,7 @@ final class RenameElementAddPrefixTest extends TestCase
               <r:second id="2" />
               <r:third id="3" />
             </r:root>
-            XML
-        );
+            XML);
         $this->assertEquals($expected->saveXML(), $document->saveXML());
     }
 
@@ -43,16 +41,14 @@ final class RenameElementAddPrefixTest extends TestCase
     {
         $document = $this->createDocument(<<<XML
             <r:root xmlns:r="http://tempuri.org/root" xmlns="http://www.sat.gob.mx/cfd/3"/>
-            XML
-        );
+            XML);
 
         $cleaner = new RenameElementAddPrefix();
         $cleaner->clean($document);
 
         $expected = $this->createDocument(<<<XML
             <r:root xmlns:r="http://tempuri.org/root"/>
-            XML
-        );
+            XML);
         $this->assertEquals($expected->saveXML(), $document->saveXML());
     }
 
@@ -60,16 +56,14 @@ final class RenameElementAddPrefixTest extends TestCase
     {
         $document = $this->createDocument(<<<XML
             <r:root xmlns:r="http://tempuri.org/root" xmlns=""/>
-            XML
-        );
+            XML);
 
         $cleaner = new RenameElementAddPrefix();
         $cleaner->clean($document);
 
         $expected = $this->createDocument(<<<XML
             <r:root xmlns:r="http://tempuri.org/root"/>
-            XML
-        );
+            XML);
         $this->assertEquals($expected->saveXML(), $document->saveXML());
     }
 }

--- a/tests/Features/XmlDocumentCleaners/SetKnownSchemaLocationsTest.php
+++ b/tests/Features/XmlDocumentCleaners/SetKnownSchemaLocationsTest.php
@@ -24,8 +24,7 @@ final class SetKnownSchemaLocationsTest extends TestCase
               />
             </cfdi:Complemento>
             </cfdi:Comprobante>
-            XML
-        );
+            XML);
 
         $cleaner = new SetKnownSchemaLocations();
         $cleaner->clean($document);
@@ -43,8 +42,7 @@ final class SetKnownSchemaLocationsTest extends TestCase
               />
             </cfdi:Complemento>
             </cfdi:Comprobante>
-            XML
-        );
+            XML);
         $this->assertEquals($expected, $document);
     }
 
@@ -54,8 +52,7 @@ final class SetKnownSchemaLocationsTest extends TestCase
             <cfdi:Comprobante xmlns:cfdi="http://www.sat.gob.mx/cfd/3"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="http://www.sat.gob.mx/cfd/3 cfdi.xsd"/>
-            XML
-        );
+            XML);
 
         $cleaner = new SetKnownSchemaLocations();
         $cleaner->clean($document);
@@ -64,8 +61,7 @@ final class SetKnownSchemaLocationsTest extends TestCase
             <cfdi:Comprobante xmlns:cfdi="http://www.sat.gob.mx/cfd/3"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="http://www.sat.gob.mx/cfd/3 cfdi.xsd"/>
-            XML
-        );
+            XML);
         $this->assertEquals($expected, $document);
     }
 
@@ -74,8 +70,7 @@ final class SetKnownSchemaLocationsTest extends TestCase
         $document = $this->createDocument(<<<XML
             <foo:Foo xmlns:foo="http://tempuri.org/foo" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="http://tempuri.org/foo foo.xsd" />
-            XML
-        );
+            XML);
 
         $cleaner = new SetKnownSchemaLocations();
         $cleaner->clean($document);
@@ -83,8 +78,7 @@ final class SetKnownSchemaLocationsTest extends TestCase
         $expected = $this->createDocument(<<<XML
             <foo:Foo xmlns:foo="http://tempuri.org/foo" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="http://tempuri.org/foo foo.xsd" />
-            XML
-        );
+            XML);
         $this->assertEquals($expected, $document);
     }
 

--- a/tests/Unit/Internal/XmlNamespaceMethodsTraitTest.php
+++ b/tests/Unit/Internal/XmlNamespaceMethodsTraitTest.php
@@ -55,8 +55,7 @@ final class XmlNamespaceMethodsTraitTest extends TestCase
             <root:root xmlns:root="http://tempuri.org/root" xmlns:unused="http://tempuri.org/unused">
               <foo:foo xmlns:foo="http://tempuri.org/foo"/>
             </root:root>
-            XML
-        );
+            XML);
 
         $this->assertSame($namespaces, $specimen->obtainNamespaces($document));
 
@@ -71,8 +70,7 @@ final class XmlNamespaceMethodsTraitTest extends TestCase
             <root:root xmlns:root="http://tempuri.org/root">
               <foo:foo xmlns:foo="http://tempuri.org/foo"/>
             </root:root>
-            XML
-        );
+            XML);
         $this->assertEquals($expected, $document);
     }
 


### PR DESCRIPTION
Se agrega la definición del espacio de nombres de *Ingresos de Hidrocarburos 1.0* a `SetKnownSchemaLocations`.
Con esta actualización se corrige el proceso de integración continua.

Se corrige el estilo de código:

- Se modifican los textos HEREDOC usados como argumentos de funciones.
- Se actualiza `php-cs-fixer` de `3.6.0` a `3.8.0`.
