### PR TITLE
Version 1.2.2, improve fix xmlns:schemaLocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ las herramientas de detección de `MIME` no reconocen un archivo XML si no trae 
 #### `XmlNsSchemaLocation`
 
 Elimina un error frecuentemente encontrado en los CFDI emitidos por el SAT donde dice `xmlns:schemaLocation`
-en lugar de `xsi:schemaLocation`.
+en lugar de `xsi:schemaLocation`. En caso de que existan ambos, el único que se mantiene es `xsi:schemaLocation`.
 
 ### Limpiezas sobre el documento XML (`DOMDocument`)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,13 @@ Utilizamos [Versionado Semántico 2.0.0](SEMVER.md).
 
 Los cambios no liberados se integran a la rama principal, pero no requieren de la liberación de una nueva versión.
 
+## Versión 1.2.2
+
+Se modifica el limpiador `XmlNsSchemaLocation` para que la limpieza se realice a nivel elemento XML.
+Si no existe un atributo `xsi:schemaLocation` entonces el atributo `xmlns:schemaLocation` es renombrado.
+Si ya existe un atributo `xsi:schemaLocation` entonces el atributo `xmlns:schemaLocation` es eliminado.
+Esta modificación cierra el *issue* #13.
+
 ## Versión 1.2.1
 
 Se agrega la definición del espacio de nombres de *Ingresos de Hidrocarburos 1.0* a `SetKnownSchemaLocations`.

--- a/src/XmlStringCleaners/XmlNsSchemaLocation.php
+++ b/src/XmlStringCleaners/XmlNsSchemaLocation.php
@@ -10,6 +10,37 @@ class XmlNsSchemaLocation implements XmlStringCleanerInterface
 {
     public function clean(string $xml): string
     {
-        return preg_replace('/(\s)xmlns:schemaLocation="/', '$1xsi:schemaLocation="', $xml) ?? '';
+        if (! str_contains($xml, 'xmlns:schemaLocation="')) {
+            // nothing to do
+            return $xml;
+        }
+
+        preg_match_all('/<(?>\s|.)*?>/u', $xml, $matches);
+        /** @var array<int, string> $parts */
+        $parts = preg_split('/<(?>\s|.)*?>/u', $xml);
+
+        $buffer = [$parts[0]];
+        foreach ($matches[0] as $index => $match) {
+            $buffer[] = $this->cleanTagContent($match);
+            $buffer[] = $parts[$index + 1];
+        }
+
+        return implode('', $buffer);
+    }
+
+    private function cleanTagContent(string $content): string
+    {
+        if (! str_contains($content, 'xmlns:schemaLocation="')) {
+            // nothing to do
+            return $content;
+        }
+
+        if (! str_contains($content, 'xsi:schemaLocation="')) {
+            // safely replace to "xsi:schemaLocation"
+            return preg_replace('/(\s)xmlns:schemaLocation="/', '$1xsi:schemaLocation="', $content) ?? '';
+        }
+
+        // remove xmlns:schemaLocation attribute
+        return preg_replace('/(\s)*xmlns:schemaLocation="(.|\s)*?"/', '', $content) ?? '';
     }
 }

--- a/tests/Features/XmlStringCleaners/RepairXmlNsSchemaLocationTest.php
+++ b/tests/Features/XmlStringCleaners/RepairXmlNsSchemaLocationTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\CfdiCleaner\XmlStringCleaners\XmlNsSchemaLocation;
 
 class RepairXmlNsSchemaLocationTest extends TestCase
 {
-    /** @return array<array{string, string}> */
+    /** @return array<string, array{string, string}> */
     public function providerInputCases(): array
     {
         return [
@@ -24,6 +24,32 @@ class RepairXmlNsSchemaLocationTest extends TestCase
             'line feed' => [
                 "<root\nxsi:schemaLocation=\"http://localhost/a http://localhost/a.xsd\"/>",
                 "<root\nxmlns:schemaLocation=\"http://localhost/a http://localhost/a.xsd\"/>",
+            ],
+            'first xsi then xmlns' => [
+                <<< EOT
+                    <root foo="bar"
+                          xsi:schemaLocation="http://localhost/a http://localhost/a.xsd">
+                    </root>
+                    EOT,
+                <<< EOT
+                    <root foo="bar"
+                          xsi:schemaLocation="http://localhost/a http://localhost/a.xsd"
+                          xmlns:schemaLocation="foo bar">
+                    </root>
+                    EOT,
+            ],
+            'first xmlns then xsi' => [
+                <<< EOT
+                    <root foo="bar"
+                          xsi:schemaLocation="http://localhost/a http://localhost/a.xsd">
+                    </root>
+                    EOT,
+                <<< EOT
+                    <root foo="bar"
+                          xmlns:schemaLocation="foo bar"
+                          xsi:schemaLocation="http://localhost/a http://localhost/a.xsd">
+                    </root>
+                    EOT,
             ],
         ];
     }


### PR DESCRIPTION
When `xsi:schemaLocation` is present the attribute `xmlns:schemaLocation` is removed.
When `xsi:schemaLocation` is not present the attribute `xmlns:schemaLocation` is renamed.
Closes #13