### PR TITLE
Mantenimiento 2022-06-21 (versión 1.2.4)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           coverage: none
-          tools: composer:v2, cs2pr, phpcs
+          tools: cs2pr, phpcs
         env:
           fail-fast: true
       - name: Code style (phpcs)
@@ -34,13 +34,13 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           coverage: none
-          tools: composer:v2, cs2pr, php-cs-fixer
+          tools: cs2pr, php-cs-fixer
         env:
           fail-fast: true
       - name: Code style (php-cs-fixer)
@@ -51,11 +51,11 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           coverage: none
           tools: composer:v2, phpstan:1.4.6
         env:
@@ -64,7 +64,7 @@ jobs:
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -82,7 +82,7 @@ jobs:
         php-versions: ['7.3', '7.4', '8.0', '8.1']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -95,7 +95,7 @@ jobs:
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           coverage: xdebug
           tools: composer:v2
         env:
@@ -27,7 +27,7 @@ jobs:
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -37,7 +37,7 @@ jobs:
       - name: Create code coverage
         run: vendor/bin/phpunit --testdox --verbose --coverage-xml=build/coverage --coverage-clover=build/coverage/clover.xml --log-junit=build/coverage/junit.xml
       - name: Store code coverage
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: code-coverage
           path: build/coverage
@@ -72,20 +72,20 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Unshallow clone to provide blame information
         run: git fetch --unshallow
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           coverage: none
           tools: composer:v2
       - name: Get composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -93,7 +93,7 @@ jobs:
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
       - name: Obtain code coverage
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: code-coverage
           path: build/coverage

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="phpcs" version="^3.6.2" installed="3.6.2" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.6.2" installed="3.6.2" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpcs" version="^3.7.1" installed="3.7.1" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.7.1" installed="3.7.1" location="./tools/phpcbf" copy="false"/>
   <phar name="php-cs-fixer" version="^3.8.0" installed="3.8.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpstan" version="1.4.6" installed="1.4.6" location="./tools/phpstan" copy="false"/>
+  <phar name="phpstan" version="^1.7.15" installed="1.7.15" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,23 @@ Utilizamos [Versionado Semántico 2.0.0](SEMVER.md).
 
 Los cambios no liberados se integran a la rama principal, pero no requieren de la liberación de una nueva versión.
 
+## Versión 1.2.4
+
+Se corrigen los limpiadores `RemoveAddenda` y `CollapseComplemento` porque no estaban actuando sobre CFDI 4.0.
+Gracias `@luffynando`.
+
+El problema de fondo es que la clase `Cfdi3XPath` solo actuaba sobre el XML namespace `http://www.sat.gob.mx/cfd/3` 
+y nunca sobre `http://www.sat.gob.mx/cfd/4`. En la corrección se renombra la clase interna `Cfdi3XPath` a `CfdiXPath` 
+y esta clase actúa sobre el XML namespace del nodo principal siempre que sea `http://www.sat.gob.mx/cfd/3` 
+y `http://www.sat.gob.mx/cfd/4`.
+
+Se refactoriza internamente la clase `CfdiXPath` y ahora incluye un método `querySchemaLocations`.
+
+Se actualizan las librerías de desarrollo y el estilo de código. Siendo lo más importante la actualización de
+PHPStan 1.7.15 que lleva a múltiples definiciones de tipos.
+
+Se actualizan los flujos de trabajo de GitHub para usar PHP 8.1 y las acciones de GitHub en versión 3.
+
 ## Versión 1.2.3
 
 La limpieza de CFDI grandes tardaba mucho tiempo en el limpiador `RemoveUnusedNamespaces`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6,5 +6,4 @@
 
 ## Actualizaciones
 
-- Actualizar PHPStan a una versión mayor de 1.4.6. 
-  A partir de la versión 1.4.7 parece que el tipo de `DOMNodeList<T>` no se reconoce.
+*Listar aquí las tareas pendientes*.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="EngineWorks">
+<ruleset name="EngineWorks">
     <description>The EngineWorks (PSR-2 based) coding standard.</description>
 
     <file>src</file>
@@ -9,8 +9,9 @@
     <arg name="encoding" value="utf-8"/>
     <arg name="report-width" value="auto"/>
     <arg name="extensions" value="php"/>
+    <arg name="cache" value="build/phpcs.cache"/>
 
-    <rule ref="PSR2"/>
+    <rule ref="PSR12"/>
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
     <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
     <rule ref="Generic.CodeAnalysis.UnconditionalIfStatement"/>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,4 @@
 parameters:
-    inferPrivatePropertyTypeFromConstructor: true
     level: max
     paths:
         - src/

--- a/src/Internal/Cfdi3XPath.php
+++ b/src/Internal/Cfdi3XPath.php
@@ -37,7 +37,9 @@ class Cfdi3XPath
      */
     public function queryElements(string $xpathQuery): DOMNodeList
     {
-        return $this->xpath->query($xpathQuery, null, false) ?: new DOMNodeList();
+        /** @var DOMNodeList<DOMElement> $list PHPStan does not detect empry DOMNodeList subtype */
+        $list = $this->xpath->query($xpathQuery, null, false) ?: new DOMNodeList();
+        return $list;
     }
 
     /**
@@ -46,6 +48,8 @@ class Cfdi3XPath
      */
     public function queryAttributes(string $xpathQuery): DOMNodeList
     {
-        return $this->xpath->query($xpathQuery, null, false) ?: new DOMNodeList();
+        /** @var DOMNodeList<DOMAttr> $list PHPStan does not detect empry DOMNodeList subtype */
+        $list = $this->xpath->query($xpathQuery, null, false) ?: new DOMNodeList();
+        return $list;
     }
 }

--- a/src/Internal/CfdiXPath.php
+++ b/src/Internal/CfdiXPath.php
@@ -46,9 +46,19 @@ class CfdiXPath
      */
     public function queryElements(string $xpathQuery): DOMNodeList
     {
-        /** @var DOMNodeList<DOMElement> $list PHPStan does not detect empry DOMNodeList subtype */
+        /** @var DOMNodeList<DOMElement> $list PHPStan does not detect empty DOMNodeList subtype */
         $list = $this->xpath->query($xpathQuery, null, false) ?: new DOMNodeList();
         return $list;
+    }
+
+    /**
+     * Get all XMLSchema instance attributes schemaLocation
+     *
+     * @return DOMNodeList<DOMAttr>
+     */
+    public function querySchemaLocations(): DOMNodeList
+    {
+        return $this->queryAttributes('//@xsi:schemaLocation');
     }
 
     /**
@@ -57,7 +67,7 @@ class CfdiXPath
      */
     public function queryAttributes(string $xpathQuery): DOMNodeList
     {
-        /** @var DOMNodeList<DOMAttr> $list PHPStan does not detect empry DOMNodeList subtype */
+        /** @var DOMNodeList<DOMAttr> $list PHPStan does not detect empty DOMNodeList subtype */
         $list = $this->xpath->query($xpathQuery, null, false) ?: new DOMNodeList();
         return $list;
     }

--- a/src/Internal/CfdiXPath.php
+++ b/src/Internal/CfdiXPath.php
@@ -13,8 +13,13 @@ use DOMXPath;
 /**
  * @internal
  */
-class Cfdi3XPath
+class CfdiXPath
 {
+    public const ALLOWED_NAMESPACES = [
+        'http://www.sat.gob.mx/cfd/3',
+        'http://www.sat.gob.mx/cfd/4',
+    ];
+
     /** @var DOMXPath */
     private $xpath;
 
@@ -26,7 +31,11 @@ class Cfdi3XPath
     public static function createFromDocument(DOMDocument $document): self
     {
         $xpath = new DOMXPath($document);
-        $xpath->registerNamespace('cfdi', 'http://www.sat.gob.mx/cfd/3');
+        $rootNamespace = $document->documentElement->namespaceURI ?? '';
+        if (! in_array($rootNamespace, self::ALLOWED_NAMESPACES)) {
+            $rootNamespace = '';
+        }
+        $xpath->registerNamespace('cfdi', $rootNamespace);
         $xpath->registerNamespace('xsi', XmlConstants::NAMESPACE_XSI);
         return new self($xpath);
     }

--- a/src/Internal/XmlAttributeMethodsTrait.php
+++ b/src/Internal/XmlAttributeMethodsTrait.php
@@ -13,7 +13,10 @@ trait XmlAttributeMethodsTrait
 {
     private function attributeRemove(DOMAttr $attribute): void
     {
-        $attribute->ownerElement->removeAttribute($attribute->nodeName);
+        $ownerElement = $attribute->ownerElement;
+        if (null !== $ownerElement) {
+            $ownerElement->removeAttribute($attribute->nodeName);
+        }
     }
 
     private function attributeSetValueOrRemoveIfEmpty(DOMAttr $attribute, string $value): void

--- a/src/Internal/XmlNamespaceMethodsTrait.php
+++ b/src/Internal/XmlNamespaceMethodsTrait.php
@@ -48,7 +48,7 @@ trait XmlNamespaceMethodsTrait
     {
         $ownerElement = $namespaceNode->parentNode;
         if ($ownerElement instanceof DOMElement) {
-            $localName = ('xmlns' === $namespaceNode->localName) ? '' : $namespaceNode->localName;
+            $localName = ('xmlns' === $namespaceNode->localName) ? '' : (string) $namespaceNode->localName;
             if ($ownerElement->hasAttributeNS(XmlConstants::NAMESPACE_XMLNS, $localName)) {
                 $ownerElement->removeAttributeNS((string) $namespaceNode->nodeValue, $localName);
             }

--- a/src/XmlDocumentCleaners/CollapseComplemento.php
+++ b/src/XmlDocumentCleaners/CollapseComplemento.php
@@ -6,7 +6,7 @@ namespace PhpCfdi\CfdiCleaner\XmlDocumentCleaners;
 
 use DOMDocument;
 use DOMElement;
-use PhpCfdi\CfdiCleaner\Internal\Cfdi3XPath;
+use PhpCfdi\CfdiCleaner\Internal\CfdiXPath;
 use PhpCfdi\CfdiCleaner\Internal\XmlElementMethodsTrait;
 use PhpCfdi\CfdiCleaner\XmlDocumentCleanerInterface;
 
@@ -16,7 +16,7 @@ class CollapseComplemento implements XmlDocumentCleanerInterface
 
     public function clean(DOMDocument $document): void
     {
-        $xpath3 = Cfdi3XPath::createFromDocument($document);
+        $xpath3 = CfdiXPath::createFromDocument($document);
 
         $complementos = $xpath3->queryElements('/cfdi:Comprobante/cfdi:Complemento');
         if ($complementos->length < 2) {

--- a/src/XmlDocumentCleaners/MoveNamespaceDeclarationToRoot.php
+++ b/src/XmlDocumentCleaners/MoveNamespaceDeclarationToRoot.php
@@ -63,16 +63,16 @@ class MoveNamespaceDeclarationToRoot implements XmlDocumentCleanerInterface
             if ($rootElement === $namespaceNode->parentNode) {
                 continue; // already on root
             }
-            $nsPrefix = $namespaceNode->nodeName;
-            $nsLocation = $namespaceNode->nodeValue;
+            $nsPrefix = (string) $namespaceNode->nodeName;
+            $nsLocation = (string) $namespaceNode->nodeValue;
             $namespaces[$nsPrefix] = $namespaces[$nsPrefix] ?? $nsLocation;
             // do not iterate on overlapped
             if ($namespaces[$nsPrefix] !== $nsLocation) {
                 continue;
             }
             // soft-write the xml namespace declaration if it does not exist yet
-            if (! $rootElement->hasAttribute($namespaceNode->nodeName)) {
-                $rootElement->setAttribute($namespaceNode->nodeName, $namespaceNode->nodeValue);
+            if (! $rootElement->hasAttribute($nsPrefix)) {
+                $rootElement->setAttribute($nsPrefix, $nsLocation);
             }
         }
         // ditry hack to remove child namespace declaration
@@ -86,12 +86,10 @@ class MoveNamespaceDeclarationToRoot implements XmlDocumentCleanerInterface
                 continue;
             }
 
-            if (! $rootElement->hasAttribute($namespaceNode->nodeName)) {
-                $rootElement->setAttributeNS(
-                    XmlConstants::NAMESPACE_XMLNS,
-                    $namespaceNode->nodeName,
-                    $namespaceNode->nodeValue,
-                );
+            $nsNodeName = $namespaceNode->nodeName;
+            $nsNodeValue = $namespaceNode->nodeValue;
+            if ($nsNodeValue && ! $rootElement->hasAttribute($nsNodeName)) {
+                $rootElement->setAttributeNS(XmlConstants::NAMESPACE_XMLNS, $nsNodeName, $nsNodeValue);
             }
 
             $this->removeNamespaceNodeAttribute($namespaceNode);

--- a/src/XmlDocumentCleaners/MoveNamespaceDeclarationToRoot.php
+++ b/src/XmlDocumentCleaners/MoveNamespaceDeclarationToRoot.php
@@ -48,8 +48,10 @@ class MoveNamespaceDeclarationToRoot implements XmlDocumentCleanerInterface
                 $prefixes[$namespaceNode->nodeName] = $currentDefinition;
                 continue;
             }
-            if ($ownerElement->hasAttribute($namespaceNode->nodeName)
-                && $prefixes[$namespaceNode->nodeName] !== $currentDefinition) {
+            if (
+                $ownerElement->hasAttribute($namespaceNode->nodeName)
+                && $prefixes[$namespaceNode->nodeName] !== $currentDefinition
+            ) {
                 return true;
             }
         }

--- a/src/XmlDocumentCleaners/MoveSchemaLocationsToRoot.php
+++ b/src/XmlDocumentCleaners/MoveSchemaLocationsToRoot.php
@@ -31,7 +31,7 @@ class MoveSchemaLocationsToRoot implements XmlDocumentCleanerInterface
         $schemaLocation = SchemaLocation::createFromValue((string) $rootAttribute->nodeValue);
 
         $xpath = CfdiXPath::createFromDocument($document);
-        $schemaLocationAttributes = $xpath->queryAttributes('//@xsi:schemaLocation');
+        $schemaLocationAttributes = $xpath->querySchemaLocations();
         foreach ($schemaLocationAttributes as $schemaLocationAttribute) {
             if ($rootAttribute === $schemaLocationAttribute) {
                 continue;

--- a/src/XmlDocumentCleaners/MoveSchemaLocationsToRoot.php
+++ b/src/XmlDocumentCleaners/MoveSchemaLocationsToRoot.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace PhpCfdi\CfdiCleaner\XmlDocumentCleaners;
 
 use DOMDocument;
-use PhpCfdi\CfdiCleaner\Internal\Cfdi3XPath;
+use PhpCfdi\CfdiCleaner\Internal\CfdiXPath;
 use PhpCfdi\CfdiCleaner\Internal\SchemaLocation;
 use PhpCfdi\CfdiCleaner\Internal\XmlAttributeMethodsTrait;
 use PhpCfdi\CfdiCleaner\Internal\XmlConstants;
@@ -30,7 +30,7 @@ class MoveSchemaLocationsToRoot implements XmlDocumentCleanerInterface
         $rootAttribute = $root->getAttributeNodeNS(XmlConstants::NAMESPACE_XSI, 'schemaLocation');
         $schemaLocation = SchemaLocation::createFromValue((string) $rootAttribute->nodeValue);
 
-        $xpath = Cfdi3XPath::createFromDocument($document);
+        $xpath = CfdiXPath::createFromDocument($document);
         $schemaLocationAttributes = $xpath->queryAttributes('//@xsi:schemaLocation');
         foreach ($schemaLocationAttributes as $schemaLocationAttribute) {
             if ($rootAttribute === $schemaLocationAttribute) {

--- a/src/XmlDocumentCleaners/MoveSchemaLocationsToRoot.php
+++ b/src/XmlDocumentCleaners/MoveSchemaLocationsToRoot.php
@@ -28,7 +28,7 @@ class MoveSchemaLocationsToRoot implements XmlDocumentCleanerInterface
             $root->setAttributeNS(XmlConstants::NAMESPACE_XSI, 'xsi:schemaLocation', '');
         }
         $rootAttribute = $root->getAttributeNodeNS(XmlConstants::NAMESPACE_XSI, 'schemaLocation');
-        $schemaLocation = SchemaLocation::createFromValue($rootAttribute->nodeValue);
+        $schemaLocation = SchemaLocation::createFromValue((string) $rootAttribute->nodeValue);
 
         $xpath = Cfdi3XPath::createFromDocument($document);
         $schemaLocationAttributes = $xpath->queryAttributes('//@xsi:schemaLocation');
@@ -37,7 +37,7 @@ class MoveSchemaLocationsToRoot implements XmlDocumentCleanerInterface
                 continue;
             }
 
-            $currentSchemaLocation = SchemaLocation::createFromValue($schemaLocationAttribute->nodeValue);
+            $currentSchemaLocation = SchemaLocation::createFromValue((string) $schemaLocationAttribute->nodeValue);
             $schemaLocation->import($currentSchemaLocation);
             $this->attributeRemove($schemaLocationAttribute);
         }

--- a/src/XmlDocumentCleaners/RemoveAddenda.php
+++ b/src/XmlDocumentCleaners/RemoveAddenda.php
@@ -14,7 +14,13 @@ class RemoveAddenda implements XmlDocumentCleanerInterface
 
     public function clean(DOMDocument $document): void
     {
-        $addendas = $document->getElementsByTagNameNS('http://www.sat.gob.mx/cfd/3', 'Addenda');
+        $this->removeAddendas($document, 'http://www.sat.gob.mx/cfd/3');
+        $this->removeAddendas($document, 'http://www.sat.gob.mx/cfd/4');
+    }
+
+    private function removeAddendas(DOMDocument $document, string $namespace): void
+    {
+        $addendas = $document->getElementsByTagNameNS($namespace, 'Addenda');
         foreach ($addendas as $addenda) {
             $this->elementRemove($addenda);
         }

--- a/src/XmlDocumentCleaners/RemoveIncompleteSchemaLocations.php
+++ b/src/XmlDocumentCleaners/RemoveIncompleteSchemaLocations.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace PhpCfdi\CfdiCleaner\XmlDocumentCleaners;
 
 use DOMDocument;
-use PhpCfdi\CfdiCleaner\Internal\Cfdi3XPath;
+use PhpCfdi\CfdiCleaner\Internal\CfdiXPath;
 use PhpCfdi\CfdiCleaner\Internal\SchemaLocation;
 use PhpCfdi\CfdiCleaner\Internal\XmlAttributeMethodsTrait;
 use PhpCfdi\CfdiCleaner\XmlDocumentCleanerInterface;
@@ -16,7 +16,7 @@ class RemoveIncompleteSchemaLocations implements XmlDocumentCleanerInterface
 
     public function clean(DOMDocument $document): void
     {
-        $xpath = Cfdi3XPath::createFromDocument($document);
+        $xpath = CfdiXPath::createFromDocument($document);
         $schemaLocations = $xpath->queryAttributes('//@xsi:schemaLocation');
         foreach ($schemaLocations as $schemaLocation) {
             $value = $this->cleanSchemaLocationValue($schemaLocation->value);

--- a/src/XmlDocumentCleaners/RemoveIncompleteSchemaLocations.php
+++ b/src/XmlDocumentCleaners/RemoveIncompleteSchemaLocations.php
@@ -17,7 +17,7 @@ class RemoveIncompleteSchemaLocations implements XmlDocumentCleanerInterface
     public function clean(DOMDocument $document): void
     {
         $xpath = CfdiXPath::createFromDocument($document);
-        $schemaLocations = $xpath->queryAttributes('//@xsi:schemaLocation');
+        $schemaLocations = $xpath->querySchemaLocations();
         foreach ($schemaLocations as $schemaLocation) {
             $value = $this->cleanSchemaLocationValue($schemaLocation->value);
             $this->attributeSetValueOrRemoveIfEmpty($schemaLocation, $value);

--- a/src/XmlDocumentCleaners/RemoveNonSatNamespacesNodes.php
+++ b/src/XmlDocumentCleaners/RemoveNonSatNamespacesNodes.php
@@ -37,7 +37,7 @@ class RemoveNonSatNamespacesNodes implements XmlDocumentCleanerInterface
     {
         $namespaces = [];
         foreach ($this->iterateNonReservedNamespaces($document) as $namespaceNode) {
-            $namespaces[] = $namespaceNode->nodeValue;
+            $namespaces[] = (string) $namespaceNode->nodeValue;
         }
         return array_unique($namespaces);
     }

--- a/src/XmlDocumentCleaners/RemoveNonSatSchemaLocations.php
+++ b/src/XmlDocumentCleaners/RemoveNonSatSchemaLocations.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace PhpCfdi\CfdiCleaner\XmlDocumentCleaners;
 
 use DOMDocument;
-use PhpCfdi\CfdiCleaner\Internal\Cfdi3XPath;
+use PhpCfdi\CfdiCleaner\Internal\CfdiXPath;
 use PhpCfdi\CfdiCleaner\Internal\SchemaLocation;
 use PhpCfdi\CfdiCleaner\Internal\XmlAttributeMethodsTrait;
 use PhpCfdi\CfdiCleaner\Internal\XmlNamespaceMethodsTrait;
@@ -18,7 +18,7 @@ class RemoveNonSatSchemaLocations implements XmlDocumentCleanerInterface
 
     public function clean(DOMDocument $document): void
     {
-        $xpath = Cfdi3XPath::createFromDocument($document);
+        $xpath = CfdiXPath::createFromDocument($document);
         $schemaLocations = $xpath->queryAttributes('//@xsi:schemaLocation');
         foreach ($schemaLocations as $schemaLocation) {
             $value = $this->cleanSchemaLocationsValue($schemaLocation->value);

--- a/src/XmlDocumentCleaners/RemoveNonSatSchemaLocations.php
+++ b/src/XmlDocumentCleaners/RemoveNonSatSchemaLocations.php
@@ -19,7 +19,7 @@ class RemoveNonSatSchemaLocations implements XmlDocumentCleanerInterface
     public function clean(DOMDocument $document): void
     {
         $xpath = CfdiXPath::createFromDocument($document);
-        $schemaLocations = $xpath->queryAttributes('//@xsi:schemaLocation');
+        $schemaLocations = $xpath->querySchemaLocations();
         foreach ($schemaLocations as $schemaLocation) {
             $value = $this->cleanSchemaLocationsValue($schemaLocation->value);
             $this->attributeSetValueOrRemoveIfEmpty($schemaLocation, $value);

--- a/src/XmlDocumentCleaners/RemoveUnusedNamespaces.php
+++ b/src/XmlDocumentCleaners/RemoveUnusedNamespaces.php
@@ -41,6 +41,9 @@ class RemoveUnusedNamespaces implements XmlDocumentCleanerInterface
     private function checkNamespaceNode($namespaceNode): void
     {
         $namespace = $namespaceNode->nodeValue;
+        if (null === $namespace) {
+            return;
+        }
         $prefix = ('' !== strval($namespaceNode->prefix)) ? $namespaceNode->prefix . ':' : '';
 
         if (! $this->isPrefixedNamespaceOnUseCached($namespace, $prefix)) {

--- a/src/XmlDocumentCleaners/RenameElementAddPrefix.php
+++ b/src/XmlDocumentCleaners/RenameElementAddPrefix.php
@@ -15,7 +15,6 @@ final class RenameElementAddPrefix implements XmlDocumentCleanerInterface
 
     public function clean(DOMDocument $document): void
     {
-        /** @var DOMElement|null $rootElement */
         $rootElement = $document->documentElement;
         if (null === $rootElement) {
             return;

--- a/src/XmlDocumentCleaners/SetKnownSchemaLocations.php
+++ b/src/XmlDocumentCleaners/SetKnownSchemaLocations.php
@@ -172,7 +172,7 @@ class SetKnownSchemaLocations implements XmlDocumentCleanerInterface
 
     private function cleanNodeAttribute(DOMDocument $document, DOMAttr $attribute): void
     {
-        $schemaLocation = SchemaLocation::createFromValue($attribute->nodeValue);
+        $schemaLocation = SchemaLocation::createFromValue((string) $attribute->nodeValue);
         foreach ($schemaLocation->getPairs() as $namespace => $location) {
             $version = $this->obtainVersionOfNamespace($document, $namespace);
             $location = $this->obtainLocationForNamespaceVersion($namespace, $version, $location);

--- a/src/XmlDocumentCleaners/SetKnownSchemaLocations.php
+++ b/src/XmlDocumentCleaners/SetKnownSchemaLocations.php
@@ -160,7 +160,7 @@ class SetKnownSchemaLocations implements XmlDocumentCleanerInterface
     public function clean(DOMDocument $document): void
     {
         $xpath = CfdiXPath::createFromDocument($document);
-        $schemaLocationAttributes = $xpath->queryAttributes('//@xsi:schemaLocation');
+        $schemaLocationAttributes = $xpath->querySchemaLocations();
         foreach ($schemaLocationAttributes as $schemaLocationAttribute) {
             $this->cleanNodeAttribute($document, $schemaLocationAttribute);
         }

--- a/src/XmlDocumentCleaners/SetKnownSchemaLocations.php
+++ b/src/XmlDocumentCleaners/SetKnownSchemaLocations.php
@@ -6,11 +6,10 @@ namespace PhpCfdi\CfdiCleaner\XmlDocumentCleaners;
 
 use DOMAttr;
 use DOMDocument;
-use DOMNodeList;
 use DOMXPath;
+use PhpCfdi\CfdiCleaner\Internal\CfdiXPath;
 use PhpCfdi\CfdiCleaner\Internal\SchemaLocation;
 use PhpCfdi\CfdiCleaner\Internal\XmlAttributeMethodsTrait;
-use PhpCfdi\CfdiCleaner\Internal\XmlConstants;
 use PhpCfdi\CfdiCleaner\Internal\XmlNamespaceMethodsTrait;
 use PhpCfdi\CfdiCleaner\XmlDocumentCleanerInterface;
 
@@ -160,11 +159,8 @@ class SetKnownSchemaLocations implements XmlDocumentCleanerInterface
 
     public function clean(DOMDocument $document): void
     {
-        $xpath = new DOMXPath($document);
-        $xpath->registerNamespace('xs', XmlConstants::NAMESPACE_XSI);
-        /** @var DOMNodeList<DOMAttr> $schemaLocationAttributes */
-        $schemaLocationAttributes = $xpath->query('//@xs:schemaLocation', null, false);
-
+        $xpath = CfdiXPath::createFromDocument($document);
+        $schemaLocationAttributes = $xpath->queryAttributes('//@xsi:schemaLocation');
         foreach ($schemaLocationAttributes as $schemaLocationAttribute) {
             $this->cleanNodeAttribute($document, $schemaLocationAttribute);
         }

--- a/tests/Features/XmlDocumentCleaners/CollapseComplementoTest.php
+++ b/tests/Features/XmlDocumentCleaners/CollapseComplementoTest.php
@@ -60,7 +60,7 @@ class CollapseComplementoTest extends TestCase
     public function testCleanCfdiWithThreeComplementos(): void
     {
         $document = $this->createDocument(<<<XML
-            <cfdi:Comprobante xmlns:cfdi="http://www.sat.gob.mx/cfd/3">
+            <cfdi:Comprobante xmlns:cfdi="http://www.sat.gob.mx/cfd/4">
               <cfdi:Complemento>
                 <foo:Foo id="first" xmlns:foo="http://tempuri.org/foo">
                   <foo:Child/>
@@ -82,7 +82,7 @@ class CollapseComplementoTest extends TestCase
             XML);
 
         $expected = $this->createDocument(<<<XML
-            <cfdi:Comprobante xmlns:cfdi="http://www.sat.gob.mx/cfd/3">
+            <cfdi:Comprobante xmlns:cfdi="http://www.sat.gob.mx/cfd/4">
               <cfdi:Complemento>
                 <foo:Foo id="first" xmlns:foo="http://tempuri.org/foo">
                   <foo:Child/>

--- a/tests/Features/XmlDocumentCleaners/RemoveAddendaTest.php
+++ b/tests/Features/XmlDocumentCleaners/RemoveAddendaTest.php
@@ -9,22 +9,44 @@ use PhpCfdi\CfdiCleaner\XmlDocumentCleaners\RemoveAddenda;
 
 final class RemoveAddendaTest extends TestCase
 {
-    public function testCleanDocumentWithAddenda(): void
+    /** @return array<string, array{string, string}> */
+    public function providerCleanDocumentWithAddenda(): array
     {
-        $document = $this->createDocument(<<<XML
-            <x:Comprobante xmlns:x="http://www.sat.gob.mx/cfd/3">
-            <x:Addenda>
-                <o:OtherData xmlns:o="http://tempuri.org/other" foo="bar" />
-            </x:Addenda>
-            </x:Comprobante>
-            XML);
+        return [
+            'CFDI 3.3' => [
+                'http://www.sat.gob.mx/cfd/3',
+                <<<XML
+                    <x:Comprobante xmlns:x="http://www.sat.gob.mx/cfd/3">
+                    <x:Addenda>
+                        <o:OtherData xmlns:o="http://tempuri.org/other" foo="bar" />
+                    </x:Addenda>
+                    </x:Comprobante>
+                    XML,
+            ],
+            'CFDI 4.0' => [
+                'http://www.sat.gob.mx/cfd/4',
+                <<<XML
+                    <x:Comprobante xmlns:x="http://www.sat.gob.mx/cfd/4">
+                    <x:Addenda>
+                        <o:OtherData xmlns:o="http://tempuri.org/other" foo="bar" />
+                    </x:Addenda>
+                    </x:Comprobante>
+                    XML,
+            ],
+        ];
+    }
+
+    /** @dataProvider providerCleanDocumentWithAddenda */
+    public function testCleanDocumentWithAddenda(string $namespace, string $source): void
+    {
+        $document = $this->createDocument($source);
 
         $cleaner = new RemoveAddenda();
         $cleaner->clean($document);
 
         $this->assertCount(
             0,
-            $document->getElementsByTagNameNS('http://www.sat.gob.mx/cfd/3', 'Addenda'),
+            $document->getElementsByTagNameNS($namespace, 'Addenda'),
             'Addenda element should not exists after cleaning',
         );
     }

--- a/tests/Unit/Internal/CfdiXPathTest.php
+++ b/tests/Unit/Internal/CfdiXPathTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiCleaner\Tests\Unit\Internal;
+
+use PhpCfdi\CfdiCleaner\Internal\CfdiXPath;
+use PhpCfdi\CfdiCleaner\Tests\TestCase;
+
+final class CfdiXPathTest extends TestCase
+{
+    /** @return array<string, array{string}> */
+    public function providerCreateCfdiVersions(): array
+    {
+        return [
+            'CFDI 3.3' => [<<<XML
+                <cfdi:Comprobante xmlns:cfdi="http://www.sat.gob.mx/cfd/3" Version="3.3"
+                  xmlns:x="http://www.w3.org/2001/XMLSchema-instance"
+                  x:schemaLocation="http://www.sat.gob.mx/cfd/3 http://www.sat.gob.mx/sitio_internet/cfd/3/cfdv33.xsd"
+                >
+                <cfdi:Complemento>
+                  <leyendasFisc:LeyendasFiscales xmlns:leyendasFisc="http://www.sat.gob.mx/leyendasFiscales"
+                   Version="1.0" x:schemaLocation="http://www.sat.gob.mx/leyendasFiscales leyendasFisc.xsd"
+                  >
+                    <leyendasFisc:Leyenda disposicionFiscal="RESDERAUTH" norma="Art 2. Fracc. IV." textoLeyenda="..." />
+                  </leyendasFisc:LeyendasFiscales>
+                </cfdi:Complemento>
+                <cfdi:Complemento>
+                  <tfd:TimbreFiscalDigital xmlns:tfd="http://www.sat.gob.mx/TimbreFiscalDigital" Version="1.1"
+                    x:schemaLocation="http://www.sat.gob.mx/TimbreFiscalDigital TimbreFiscalDigitalv11.xsd"
+                    UUID="AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE" NoCertificadoSAT="00001000000504465028"
+                    FechaTimbrado="2022-01-12T12:39:34" RfcProvCertif="SAT970701NN3"
+                    SelloCFD="...5tSZhA==" SelloSAT="...aobTwQ=="/>
+                </cfdi:Complemento>
+                </cfdi:Comprobante>
+                XML],
+            'CFDI 4.0' => [<<<XML
+                <cfdi:Comprobante xmlns:cfdi="http://www.sat.gob.mx/cfd/4" Version="4.0"
+                  xmlns:x="http://www.w3.org/2001/XMLSchema-instance"
+                  x:schemaLocation="http://www.sat.gob.mx/cfd/4 http://www.sat.gob.mx/sitio_internet/cfd/4/cfdv40.xsd"
+                >
+                <cfdi:Complemento>
+                  <leyendasFisc:LeyendasFiscales xmlns:leyendasFisc="http://www.sat.gob.mx/leyendasFiscales"
+                   Version="1.0" x:schemaLocation="http://www.sat.gob.mx/leyendasFiscales leyendasFisc.xsd"
+                  >
+                    <leyendasFisc:Leyenda disposicionFiscal="RESDERAUTH" norma="Art 2. Fracc. IV." textoLeyenda="..." />
+                  </leyendasFisc:LeyendasFiscales>
+                </cfdi:Complemento>
+                <cfdi:Complemento>
+                  <tfd:TimbreFiscalDigital xmlns:tfd="http://www.sat.gob.mx/TimbreFiscalDigital" Version="1.1"
+                    x:schemaLocation="http://www.sat.gob.mx/TimbreFiscalDigital TimbreFiscalDigitalv11.xsd"
+                    UUID="AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE" NoCertificadoSAT="00001000000504465028"
+                    FechaTimbrado="2022-01-12T12:39:34" RfcProvCertif="SAT970701NN3"
+                    SelloCFD="...5tSZhA==" SelloSAT="...aobTwQ=="/>
+                </cfdi:Complemento>
+                </cfdi:Comprobante>
+                XML],
+        ];
+    }
+
+    /** @dataProvider providerCreateCfdiVersions */
+    public function testCreateCfdiVersions(string $source): void
+    {
+        $document = $this->createDocument($source);
+        $xpath = CfdiXPath::createFromDocument($document);
+
+        $attributes = [];
+        foreach ($xpath->queryAttributes('//cfdi:Complemento//@Version') as $attribute) {
+            $attributes[] = $attribute->nodeValue;
+        }
+        $this->assertSame(['1.0', '1.1'], $attributes);
+
+        $elements = [];
+        foreach ($xpath->queryElements('/cfdi:Comprobante/cfdi:Complemento/*') as $element) {
+            $elements[] = $element->nodeName;
+        }
+        $this->assertSame(['leyendasFisc:LeyendasFiscales', 'tfd:TimbreFiscalDigital'], $elements);
+
+        $this->assertCount(3, iterator_to_array($xpath->queryAttributes('//@xsi:schemaLocation')));
+
+        $this->assertSame([], iterator_to_array($xpath->queryAttributes('//@FOOBAR')));
+        $this->assertSame([], iterator_to_array($xpath->queryElements('//FOOBAR')));
+    }
+
+    public function testNonAllowedNamespace(): void
+    {
+        $document = $this->createDocument(
+            <<<XML
+                <cfdi:Comprobante xmlns:cfdi="http://tempuri.org/cfdi"/>
+                XML
+        );
+        $xpath = CfdiXPath::createFromDocument($document);
+        $this->assertCount(0, $xpath->queryElements('/cfdi:Comprobante'));
+    }
+
+    public function testAllowedNamespaceWithDifferentPrefix(): void
+    {
+        $document = $this->createDocument(
+            <<<XML
+                <factura:Comprobante xmlns:factura="http://www.sat.gob.mx/cfd/4"/>
+                XML
+        );
+        $xpath = CfdiXPath::createFromDocument($document);
+        $this->assertCount(1, $xpath->queryElements('/cfdi:Comprobante'));
+    }
+}

--- a/tests/Unit/Internal/CfdiXPathTest.php
+++ b/tests/Unit/Internal/CfdiXPathTest.php
@@ -76,7 +76,7 @@ final class CfdiXPathTest extends TestCase
         }
         $this->assertSame(['leyendasFisc:LeyendasFiscales', 'tfd:TimbreFiscalDigital'], $elements);
 
-        $this->assertCount(3, iterator_to_array($xpath->queryAttributes('//@xsi:schemaLocation')));
+        $this->assertCount(3, iterator_to_array($xpath->querySchemaLocations()));
 
         $this->assertSame([], iterator_to_array($xpath->queryAttributes('//@FOOBAR')));
         $this->assertSame([], iterator_to_array($xpath->queryElements('//FOOBAR')));

--- a/tests/Unit/Internal/XmlNamespaceMethodsTraitTest.php
+++ b/tests/Unit/Internal/XmlNamespaceMethodsTraitTest.php
@@ -24,7 +24,7 @@ final class XmlNamespaceMethodsTraitTest extends TestCase
             {
                 $namespaces = [];
                 foreach ($this->iterateNonReservedNamespaces($document) as $namespaceNode) {
-                    $namespaces[$namespaceNode->prefix] = $namespaceNode->nodeValue;
+                    $namespaces[$namespaceNode->prefix] = (string) $namespaceNode->nodeValue;
                 }
                 asort($namespaces);
                 return $namespaces;


### PR DESCRIPTION
Se corrigen los limpiadores `RemoveAddenda` y `CollapseComplemento` porque no estaban actuando sobre CFDI 4.0.
Gracias @luffynando.

El problema de fondo es que la clase `Cfdi3XPath` solo actuaba sobre el XML namespace `http://www.sat.gob.mx/cfd/3` 
y nunca sobre `http://www.sat.gob.mx/cfd/4`. En la corrección se renombra la clase interna `Cfdi3XPath` a `CfdiXPath` 
y esta clase actúa sobre el XML namespace del nodo principal siempre que sea `http://www.sat.gob.mx/cfd/3` 
y `http://www.sat.gob.mx/cfd/4`.

Se refactoriza internamente la clase `CfdiXPath` y ahora incluye un método `querySchemaLocations`.

Se actualizan las librerías de desarrollo y el estilo de código. Siendo lo más importante la actualización de
PHPStan 1.7.15 que lleva a múltiples definiciones de tipos.

Se actualizan los flujos de trabajo de GitHub para usar PHP 8.1 y las acciones de GitHub en versión 3.