### PR TITLE
Agregar la opción para excluir limpiadores específicos (v1.3.0)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           php-version: '8.2'
           coverage: none
-          tools: composer:v2, phpstan:1.4.6
+          tools: composer:v2, phpstan
         env:
           fail-fast: true
       - name: Get composer cache directory

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
           tools: cs2pr, phpcs
         env:
@@ -55,14 +55,14 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
           tools: composer:v2, phpstan:1.4.6
         env:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v3
         with:
@@ -79,7 +79,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2']
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -93,7 +93,7 @@ jobs:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v3
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: xdebug
           tools: composer:v2
         env:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v3
         with:
@@ -53,15 +53,15 @@ jobs:
         id: check-secrets
         run: |
           if [ -n "${{ secrets.GITHUB_TOKEN }}" ]; then
-            echo "::set-output name=github::yes"
+            echo "github=yes" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=github::no"
+            echo "github=no" >> $GITHUB_OUTPUT
             echo "::warning ::GITHUB_TOKEN non set"
           fi
           if [ -n "${{ secrets.SONAR_TOKEN }}" ]; then
-            echo "::set-output name=sonar::yes"
+            echo "sonar=yes" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=sonar::no"
+            echo "sonar=no" >> $GITHUB_OUTPUT
             echo "::warning ::SONAR_TOKEN non set"
           fi
 
@@ -78,12 +78,12 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
           tools: composer:v2
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v3
         with:

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -2,6 +2,6 @@
 <phive xmlns="https://phar.io/phive">
   <phar name="phpcs" version="^3.7.1" installed="3.7.1" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.7.1" installed="3.7.1" location="./tools/phpcbf" copy="false"/>
-  <phar name="php-cs-fixer" version="^3.8.0" installed="3.8.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpstan" version="^1.7.15" installed="1.7.15" location="./tools/phpstan" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.13.1" installed="3.13.1" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpstan" version="^1.9.4" installed="1.9.4" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -23,11 +23,12 @@ return (new PhpCsFixer\Config())
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
         'function_typehint_space' => true,
+        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays']],
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,
         'binary_operator_spaces' => true,
         'phpdoc_scalar' => true,
-        'no_trailing_comma_in_singleline_array' => true,
+        'no_trailing_comma_in_singleline' => true,
         'single_quote' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_unused_imports' => true,
@@ -35,11 +36,13 @@ return (new PhpCsFixer\Config())
         'standardize_not_equals' => true,
         'concat_space' => ['spacing' => 'one'],
         'linebreak_after_opening_tag' => true,
+        'fully_qualified_strict_types' => true,
         // symfony:risky
         'no_alias_functions' => true,
         'self_accessor' => true,
         // contrib
         'not_operator_with_successor_space' => true,
+        'ordered_imports' => ['imports_order' => ['class', 'function', 'const']], // @PSR12 sort_algorithm: none
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()

--- a/README.md
+++ b/README.md
@@ -233,6 +233,39 @@ Sin embargo, en el archivo de validación XSD permite que existan más de uno.
 
 Con esta limpieza, se deja un solo `cfdi:Complemento` con todos los complementos en él.
 
+### Exclusión de limpiadores
+
+Para no tener que modificar la creación del objeto limpiador y permitir la exclusión de limpiadores específicos,
+y de esta forma ser compatibles con nuevas actualizaciones de la librería, se puede crear el limpiador estándar
+y luego aplicar exclusiones.
+
+El siguiente ejemplo muestra cómo excluir los limpiadores que afectan a una *Addenda*.
+
+```php
+<?php
+
+use PhpCfdi\CfdiCleaner\Cleaner;
+use PhpCfdi\CfdiCleaner\ExcludeList;
+use PhpCfdi\CfdiCleaner\XmlDocumentCleaners\RemoveAddenda,
+use PhpCfdi\CfdiCleaner\XmlDocumentCleaners\RemoveNonSatNamespacesNodes,
+use PhpCfdi\CfdiCleaner\XmlDocumentCleaners\RemoveNonSatSchemaLocations,
+
+/**
+ * @var string $contents El contenido XML sucio.
+ */
+
+$exclude = new ExcludeList(
+    RemoveAddenda::class,
+    RemoveNonSatNamespacesNodes::class,
+    RemoveNonSatSchemaLocations::class,
+);
+
+$cleaner = new Cleaner();
+$cleaner->exclude($exclude);
+
+$contents = $cleaner->cleanStringToString($contents);
+```
+
 ## Soporte
 
 Puedes obtener soporte abriendo un ticket en Github.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Remueve todas las declaraciones de espacios de nombres (junto con su prefijo) qu
 #### `RenameElementAddPrefix`
 
 Agrega el prefijo al nodo que no lo tiene por estar utilizando la definición simple `xmlns`.
-Además elimina los namespace superfluos y las definiciones `xmlns` redundantes.
+Además, elimina los namespace superfluos y las definiciones `xmlns` redundantes.
 
 Ejemplo de CFDI sucio:
 
@@ -171,7 +171,7 @@ Ejemplo de CFDI limpio:
 Mueve todas las declaraciones de espacios de nombres al nodo raíz.
 
 Por lo regular el SAT pide en la documentación técnica que los espacios de nombres se definan en el nodo raíz,
-sin embargo es frecuente que se definan en el nodo que los implementa.
+sin embargo, es frecuente que se definan en el nodo que los implementa.
 
 Hay casos extremos de CFDI que siguen las reglas de XML, pero que no siguen las reglas de CFDI y generan prefijos
 que se superponen. En este caso, se moverán solamente los espacios de nombres que no se superponen, por ejemplo:
@@ -207,14 +207,14 @@ sustitución por un CFDI que sí contenga los prefijos de los espacios de nombre
 Mueve todas las declaraciones de ubicaciones de archivos de esquema al nodo principal.
 
 Por lo regular el SAT pide en la documentación técnica que las ubicaciones de archivos de esquema se definan en
-el nodo principal, sin embargo es frecuente que se definan en el nodo que los implementa.
+el nodo principal, sin embargo, es frecuente que se definan en el nodo que los implementa.
 
 #### `SetKnownSchemaLocations`
 
 Verifica que las ubicaciones de los esquemas de espacios de nombres conocidos sean exactamente las direcciones conocidas,
 en caso de no serlo las modifican.
 
-Anteriormente el SAT permitía que las ubicaciones de los esquemas de espacios de nombres estuvieran escritos sin
+Anteriormente, el SAT permitía que las ubicaciones de los esquemas de espacios de nombres estuvieran escritos sin
 sensibilidad a mayúsculas o minúsculas, incluso tenía varias ubicaciones para obtener estos archivos. Sin embargo,
 recientemente ha eliminado la tolerancia a estas ubicaciones y solo permite las definiciones oficiales.
 
@@ -279,7 +279,7 @@ and licensed for use under the MIT License (MIT). Please see [LICENSE][] for mor
 [badge-php-version]: https://img.shields.io/packagist/php-v/phpcfdi/cfdi-cleaner?logo=php
 [badge-release]: https://img.shields.io/github/release/phpcfdi/cfdi-cleaner?logo=git
 [badge-license]: https://img.shields.io/github/license/phpcfdi/cfdi-cleaner?logo=open-source-initiative
-[badge-build]: https://img.shields.io/github/workflow/status/phpcfdi/cfdi-cleaner/build/main?logo=github-actions
+[badge-build]: https://img.shields.io/github/actions/workflow/status/phpcfdi/cfdi-cleaner/build.yml?branch=main&logo=github-actions
 [badge-reliability]: https://sonarcloud.io/api/project_badges/measure?project=phpcfdi_cfdi-cleaner&metric=reliability_rating
 [badge-maintainability]: https://sonarcloud.io/api/project_badges/measure?project=phpcfdi_cfdi-cleaner&metric=sqale_rating
 [badge-coverage]: https://img.shields.io/sonar/coverage/phpcfdi_cfdi-cleaner/main?logo=sonarcloud&server=https%3A%2F%2Fsonarcloud.io

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,21 @@ Utilizamos [Versionado Semántico 2.0.0](SEMVER.md).
 
 Los cambios no liberados se integran a la rama principal, pero no requieren de la liberación de una nueva versión.
 
+## Versión 1.3.0
+
+Se agrega la opción de excluir limpiadores específicos por nombre de clase.
+En futuras versiones se implementará una mejor manera de manejar estas exclusiones.
+La implementación actual no genera cambios que rompan la compatibilidad y requieran una versión mayor.
+
+### Cambios de mantenimiento
+
+- Se aplicó en los flujos de trabajo:
+  - Incluir PHP 8.2 a la matriz de pruebas.
+  - Ejecutar todo en PHP 8.2 excepto el trabajo `php-cs-fixer`.
+  - Sustituir la instrucción `::set-output` con el uso del archivo `$GITHUB_OUTPUT`.
+- Se corrigió la insignia `badge-build`.
+- Se actualizaron los archivos de estilo de código a las reglas utilizadas en los últimos proyectos.
+
 ## Versión 1.2.4
 
 Se corrigen los limpiadores `RemoveAddenda` y `CollapseComplemento` porque no estaban actuando sobre CFDI 4.0.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ La implementación actual no genera cambios que rompan la compatibilidad y requi
   - Incluir PHP 8.2 a la matriz de pruebas.
   - Ejecutar todo en PHP 8.2 excepto el trabajo `php-cs-fixer`.
   - Sustituir la instrucción `::set-output` con el uso del archivo `$GITHUB_OUTPUT`.
+  - Se removió la restricción de versión fija de PHPStan.
 - Se corrigió la insignia `badge-build`.
 - Se actualizaron los archivos de estilo de código a las reglas utilizadas en los últimos proyectos.
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="EngineWorks">
-    <description>The EngineWorks (PSR-2 based) coding standard.</description>
+    <description>The EngineWorks (PSR-12 based) coding standard.</description>
 
     <file>src</file>
     <file>tests</file>

--- a/src/Cleaner.php
+++ b/src/Cleaner.php
@@ -20,6 +20,12 @@ class Cleaner
         $this->xmlCleaners = $xmlCleaners ?? XmlDocumentCleaners::createDefault();
     }
 
+    public function exclude(ExcludeList $excludeList): void
+    {
+        $this->stringCleaners = $this->stringCleaners->withOutCleaners($excludeList);
+        $this->xmlCleaners = $this->xmlCleaners->withOutCleaners($excludeList);
+    }
+
     public static function staticClean(string $xml): string
     {
         return (new self())->cleanStringToString($xml);

--- a/src/ExcludeList.php
+++ b/src/ExcludeList.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiCleaner;
+
+use ArrayIterator;
+use IteratorAggregate;
+use Traversable;
+
+/**
+ * Class to specify the cleaner class names to be excluded
+ * @see Cleaner::exclude()
+ * @implements IteratorAggregate<int, class-string>
+ */
+final class ExcludeList implements IteratorAggregate
+{
+    /** @var list<class-string> */
+    private $classNames;
+
+    /** @param class-string ...$classNames */
+    public function __construct(string ...$classNames)
+    {
+        $this->classNames = array_values($classNames);
+    }
+
+    public function isEmpty(): bool
+    {
+        return [] === $this->classNames;
+    }
+
+    public function match(object $object): bool
+    {
+        foreach ($this->classNames as $className) {
+            if ($object instanceof $className) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @template TObject of object
+     * @param TObject ...$objects
+     * @return array<TObject>
+     */
+    public function filterObjects(object ...$objects): array
+    {
+        return array_filter(
+            $objects,
+            function (object $object): bool {
+                return ! $this->match($object);
+            }
+        );
+    }
+
+    /** @return Traversable<int, class-string> */
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->classNames);
+    }
+}

--- a/src/XmlDocumentCleaners.php
+++ b/src/XmlDocumentCleaners.php
@@ -38,4 +38,10 @@ class XmlDocumentCleaners implements XmlDocumentCleanerInterface
             $cleaner->clean($document);
         }
     }
+
+    public function withOutCleaners(ExcludeList $excludeList): self
+    {
+        $cleaners = $excludeList->filterObjects(...$this->cleaners);
+        return new self(...$cleaners);
+    }
 }

--- a/src/XmlStringCleaners.php
+++ b/src/XmlStringCleaners.php
@@ -31,4 +31,10 @@ class XmlStringCleaners implements XmlStringCleanerInterface
         }
         return $xml;
     }
+
+    public function withOutCleaners(ExcludeList $excludeList): self
+    {
+        $cleaners = $excludeList->filterObjects(...$this->cleaners);
+        return new self(...$cleaners);
+    }
 }

--- a/tests/Features/CleanerExcludeTest.php
+++ b/tests/Features/CleanerExcludeTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiCleaner\Tests\Features;
+
+use PhpCfdi\CfdiCleaner\Cleaner;
+use PhpCfdi\CfdiCleaner\ExcludeList;
+use PhpCfdi\CfdiCleaner\Tests\TestCase;
+use PhpCfdi\CfdiCleaner\XmlDocumentCleaners\MoveNamespaceDeclarationToRoot;
+use PhpCfdi\CfdiCleaner\XmlDocumentCleaners\RemoveAddenda;
+use PhpCfdi\CfdiCleaner\XmlDocumentCleaners\RemoveNonSatNamespacesNodes;
+use PhpCfdi\CfdiCleaner\XmlDocumentCleaners\RemoveNonSatSchemaLocations;
+
+final class CleanerExcludeTest extends TestCase
+{
+    public function testCleanerExcludeAddenda(): void
+    {
+        $xml = /** @lang text */ <<<XML
+            <?xml version="1.0"?>
+            <cfdi:Comprobante xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:cfdi="http://www.sat.gob.mx/cfd/4"
+            xsi:schemaLocation="http://www.sat.gob.mx/cfd/4 http://www.sat.gob.mx/sitio_internet/cfd/4/cfdv40.xsd"
+            Version="4.0">
+            <cfdi:Addenda>
+                <foo:Main xmlns:foo="urn:foo" id="1" />
+            </cfdi:Addenda>
+            </cfdi:Comprobante>
+            XML;
+
+        $excludeList = new ExcludeList(
+            RemoveAddenda::class,
+            RemoveNonSatNamespacesNodes::class,
+            RemoveNonSatSchemaLocations::class,
+            MoveNamespaceDeclarationToRoot::class
+        );
+
+        $cleaner = new Cleaner();
+        $cleaner->exclude($excludeList);
+
+        $xmlClean = $cleaner->cleanStringToString($xml);
+
+        $this->assertXmlStringEqualsXmlString($xml, $xmlClean);
+    }
+}

--- a/tests/Unit/ExcludeListTest.php
+++ b/tests/Unit/ExcludeListTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiCleaner\Tests\Unit;
+
+use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
+use DOMDocument;
+use PhpCfdi\CfdiCleaner\ExcludeList;
+use PhpCfdi\CfdiCleaner\Tests\TestCase;
+
+final class ExcludeListTest extends TestCase
+{
+    public function testConstructorWithEmptyList(): void
+    {
+        $excludeList = new ExcludeList();
+        $this->assertTrue($excludeList->isEmpty());
+        $this->assertSame([], iterator_to_array($excludeList));
+    }
+
+    public function testConstructorWithValues(): void
+    {
+        $classes = [
+            DateTime::class,
+            DateTimeImmutable::class,
+        ];
+
+        $excludeList = new ExcludeList(...$classes);
+
+        $this->assertFalse($excludeList->isEmpty());
+        $this->assertSame($classes, iterator_to_array($excludeList));
+    }
+
+    public function testMatch(): void
+    {
+        $excludeList = new ExcludeList(DateTimeInterface::class);
+        $this->assertTrue($excludeList->match(new DateTime()));
+        $this->assertTrue($excludeList->match(new DateTimeImmutable()));
+        $this->assertTrue($excludeList->match($this->createMock(DateTime::class)));
+        $this->assertFalse($excludeList->match((object) []));
+    }
+
+    public function testFilter(): void
+    {
+        $expected = [];
+        $objects = [
+            new DateTime(),
+            $expected[] = (object) [],
+            new DateTimeImmutable(),
+            $expected[] = new DOMDocument(),
+        ];
+
+        $excludeList = new ExcludeList(DateTimeInterface::class);
+        $filtered = $excludeList->filterObjects(...$objects);
+
+        $this->assertSame($expected, array_values($filtered));
+    }
+}


### PR DESCRIPTION
Se agrega la opción de excluir limpiadores específicos por nombre de clase.
En futuras versiones se implementará una mejor manera de manejar estas exclusiones.
La implementación actual no genera cambios que rompan la compatibilidad y requieran una versión mayor.

### Cambios de mantenimiento

- Se aplicó en los flujos de trabajo:
  - Incluir PHP 8.2 a la matriz de pruebas.
  - Ejecutar todo en PHP 8.2 excepto el trabajo `php-cs-fixer`.
  - Sustituir la instrucción `::set-output` con el uso del archivo `$GITHUB_OUTPUT`.
- Se corrigió la insignia `badge-build`.
- Se actualizaron los archivos de estilo de código a las reglas utilizadas en los últimos proyectos.

