### PR TITLE
Mantenimiento 2023-02-07

### DIFF
--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -2,6 +2,6 @@
 <phive xmlns="https://phar.io/phive">
   <phar name="phpcs" version="^3.7.1" installed="3.7.1" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.7.1" installed="3.7.1" location="./tools/phpcbf" copy="false"/>
-  <phar name="php-cs-fixer" version="^3.13.1" installed="3.13.1" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpstan" version="^1.9.4" installed="1.9.4" location="./tools/phpstan" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.14.3" installed="3.14.3" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpstan" version="^1.9.14" installed="1.9.14" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2021 - 2022 PhpCfdi https://www.phpcfdi.com/
+Copyright (c) 2021 - 2023 PhpCfdi https://www.phpcfdi.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,9 +4,15 @@
 
 Utilizamos [Versionado Semántico 2.0.0](SEMVER.md).
 
-## Cambios en la rama principal sin liberación de nueva versión.
+## Cambios en la rama principal sin liberación de nueva versión
 
 Los cambios no liberados se integran a la rama principal, pero no requieren de la liberación de una nueva versión.
+
+### Mantenimiento 2023-02-07
+
+- Se refactoriza una prueba porque en PHPUnit 9.6.3 se deprecó el método `expectDeprecation()`.
+- Se actualiza el año de la licencia. Feliz 2023.
+- Se actualizan las herramientas de desarrollo.
 
 ## Versión 1.3.0
 
@@ -103,7 +109,7 @@ Para corregir este problema:
 - Se elimina de la lista de limpiadores de texto por defecto a `RemoveDuplicatedCfdi3Namespace`.
 - Se quita la funcionalidad de `RemoveDuplicatedCfdi3Namespace` y se emite un `E_USER_DEPRECATED`.
 - Se crea un nuevo limpiador `RenameElementAddPrefix` que agrega el prefijo al nodo que no lo tiene por estar
-  utilizando la definición simple `xmlns`. Además elimina los namespace superfluos y las 
+  utilizando la definición simple `xmlns`. Además, elimina los namespace superfluos y las 
   definiciones `xmlns` redundantes.
 
 Ejemplo de CFDI sucio:

--- a/tests/Features/XmlStringCleaners/RemoveDuplicatedCfdi3NamespaceTest.php
+++ b/tests/Features/XmlStringCleaners/RemoveDuplicatedCfdi3NamespaceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpCfdi\CfdiCleaner\Tests\Features\XmlStringCleaners;
 
 use PhpCfdi\CfdiCleaner\Tests\TestCase;
+use PhpCfdi\CfdiCleaner\XmlDocumentCleaners\RenameElementAddPrefix;
 use PhpCfdi\CfdiCleaner\XmlStringCleaners\RemoveDuplicatedCfdi3Namespace;
 
 class RemoveDuplicatedCfdi3NamespaceTest extends TestCase
@@ -38,8 +39,18 @@ class RemoveDuplicatedCfdi3NamespaceTest extends TestCase
     public function testClean(string $expected, string $input): void
     {
         $cleaner = new RemoveDuplicatedCfdi3Namespace();
-        $this->expectDeprecation();
-        $clean = $cleaner->clean($input);
+
+        $clean = @$cleaner->clean($input);
+        $error = error_get_last() ?? [];
+
+        $expectedErrorMessage = sprintf(
+            'Class %s is deprecated, use %s',
+            RemoveDuplicatedCfdi3Namespace::class,
+            RenameElementAddPrefix::class
+        );
+
+        $this->assertSame(E_USER_DEPRECATED, intval($error['type'] ?? 0));
+        $this->assertSame($expectedErrorMessage, strval($error['message'] ?? ''));
 
         $this->assertEquals($input, $clean);
     }


### PR DESCRIPTION
Se corrige la construcción del proyecto en GitHub, con lo que se aplicaron los siguientes cambios:

- Se refactoriza una prueba porque en PHPUnit 9.6.3 se deprecó el método `expectDeprecation()`.
- Se actualiza el año de la licencia. Feliz 2023.
- Se actualizan las herramientas de desarrollo.
