### PR TITLE
Corregir la integración continua (version 1.3.2)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: cs2pr, phpcs
         env:
@@ -38,7 +38,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           coverage: none
           tools: cs2pr, php-cs-fixer
         env:
@@ -55,7 +55,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: composer:v2, phpstan
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2']
+        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: xdebug
           tools: composer:v2
         env:
@@ -78,7 +78,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
           tools: composer:v2
       - name: Get composer cache directory

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="phpcs" version="^3.7.2" installed="3.7.2" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.7.2" installed="3.7.2" location="./tools/phpcbf" copy="false"/>
-  <phar name="php-cs-fixer" version="^3.35.1" installed="3.35.1" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpstan" version="^1.10.39" installed="1.10.39" location="./tools/phpstan" copy="false"/>
+  <phar name="phpcs" version="^3.8.1" installed="3.8.1" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.8.1" installed="3.8.1" location="./tools/phpcbf" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.47.0" installed="3.47.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpstan" version="^1.10.56" installed="1.10.56" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,7 +36,7 @@ Este código de conducta aplica tanto a espacios del proyecto como a espacios p�
 
 ## Aplicación
 
-Instancias de comportamiento abusivo, acosador o inaceptable de otro modo podrán ser reportadas a los administradores de la comunidad responsables del cumplimiento a través de [coc@phpcfdi.com](). Todas las quejas serán evaluadas e investigadas de una manera puntual y justa.
+Instancias de comportamiento abusivo, acosador o inaceptable de otro modo podrán ser reportadas a los administradores de la comunidad responsables del cumplimiento a través de [coc@phpcfdi.com](mailto:coc@phpcfdi.com). Todas las quejas serán evaluadas e investigadas de una manera puntual y justa.
 
 Todos los administradores de la comunidad están obligados a respetar la privacidad y la seguridad de quienes reporten incidentes.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribuciones
 
-Las contribuciones son bienvenidas. Aceptamos *Pull Requests* en [el repositorio GitHub][homepage].
+Las contribuciones son bienvenidas. Aceptamos *Pull Requests* en [el repositorio GitHub][project].
 
 Este proyecto se apega al siguiente [Código de Conducta][coc].
 Al participar en este proyecto y en su comunidad, deberás seguir este código.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2021 - 2023 PhpCfdi https://www.phpcfdi.com/
+Copyright (c) 2021 - 2024 PhpCfdi https://www.phpcfdi.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ sensibilidad a mayúsculas o minúsculas, incluso tenía varias ubicaciones para
 recientemente ha eliminado la tolerancia a estas ubicaciones y solo permite las definiciones oficiales.
 
 Este limpiador tiene la información de espacio de nombres, versión a la que aplica y ubicación conocida con base en
-el proyecto [hpcfdi/sat-ns-registry](https://github.com/phpcfdi/sat-ns-registry).
+el proyecto [phpcfdi/sat-ns-registry](https://github.com/phpcfdi/sat-ns-registry).
 
 En caso de que no se encuentre la ruta conocida para un espacio de nombres entonces no aplicará ninguna corrección
 y dejará el valor tal como estaba.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,17 @@ Utilizamos [Versionado Semántico 2.0.0](SEMVER.md).
 
 Los cambios no liberados se integran a la rama principal, pero no requieren de la liberación de una nueva versión.
 
+## Versión 1.3.2
+
+- Se agrega *Comercio Exterior 2.0* a la lista de espacio de nombres conocidos.
+- Se actualiza el año de licencia.
+- Se corrige la liga al proyecto en el archivo `CONTRIBUTING.md`.
+- Se corrige el correo de comunicación en `CODE_OF_CONDUCT.md`.
+- Se aplicó en los flujos de trabajo:
+  - Se incluye PHP 8.3 a la matriz de pruebas.
+  - Ejecutar todo en PHP 8.3.
+- Se actualizan las herramientas de desarrollo.
+
 ## Versión 1.3.1
 
 - Se agrega *Carta Porte 3.0* a la lista de espacio de nombres conocidos.

--- a/src/XmlDocumentCleaners/SetKnownSchemaLocations.php
+++ b/src/XmlDocumentCleaners/SetKnownSchemaLocations.php
@@ -106,6 +106,8 @@ class SetKnownSchemaLocations implements XmlDocumentCleanerInterface
         => 'http://www.sat.gob.mx/sitio_internet/cfd/ine/ine10.xsd',
         'http://www.sat.gob.mx/ComercioExterior11#1.1'
         => 'http://www.sat.gob.mx/sitio_internet/cfd/ComercioExterior11/ComercioExterior11.xsd',
+        'http://www.sat.gob.mx/ComercioExterior20#2.0'
+        => 'http://www.sat.gob.mx/sitio_internet/cfd/ComercioExterior20/ComercioExterior20.xsd',
         'http://www.sat.gob.mx/ComercioExterior#1.0'
         => 'http://www.sat.gob.mx/sitio_internet/cfd/ComercioExterior/ComercioExterior10.xsd',
         'http://www.sat.gob.mx/Pagos#1.0'


### PR DESCRIPTION
- Se agrega *Comercio Exterior 2.0* a la lista de espacio de nombres conocidos.
- Se actualiza el año de licencia.
- Se corrige la liga al proyecto en el archivo `CONTRIBUTING.md`.
- Se corrige el correo de comunicación en `CODE_OF_CONDUCT.md`.
- Se aplicó en los flujos de trabajo:
  - Se incluye PHP 8.3 a la matriz de pruebas.
  - Ejecutar todo en PHP 8.3.
- Se actualizan las herramientas de desarrollo.
