### PR TITLE
Correcciones de ubicaciones de archivos XSD y limpieza de Addenda (versión 1.3.4)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,18 +93,18 @@ jobs:
         run: phpstan analyse --no-progress --verbose
 
   tests:
-    name: Tests on PHP ${{ matrix.php-versions }}
+    name: Tests on PHP ${{ matrix.php-version }}
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php-version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: ${{ matrix.php-version }}
           coverage: none
           tools: composer:v2
         env:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,7 @@ on:
 jobs:
 
   tests-coverage:
-    name: Tests on PHP 8.3 (code coverage)
+    name: Create code coverage
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="phpcs" version="^3.10.1" installed="3.10.1" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.10.1" installed="3.10.1" location="./tools/phpcbf" copy="false"/>
-  <phar name="php-cs-fixer" version="^3.59.3" installed="3.59.3" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpstan" version="^1.11.5" installed="1.11.5" location="./tools/phpstan" copy="false"/>
-  <phar name="composer-normalize" version="^2.43.0" installed="2.43.0" location="./tools/composer-normalize" copy="false"/>
+  <phar name="phpcs" version="^3.10.3" installed="3.10.3" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.10.3" installed="3.10.3" location="./tools/phpcbf" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.64.0" installed="3.64.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpstan" version="^1.12.6" installed="1.12.6" location="./tools/phpstan" copy="false"/>
+  <phar name="composer-normalize" version="^2.44.0" installed="2.44.0" location="./tools/composer-normalize" copy="false"/>
 </phive>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,20 @@ Utilizamos [Versionado Semántico 2.0.0](SEMVER.md).
 
 Los cambios no liberados se integran a la rama principal, pero no requieren de la liberación de una nueva versión.
 
+## Versión 1.3.4
+
+Se hacen las siguientes correcciones:
+
+- Se corrige la ubicación del XSD del complemento "Enajenaciones de acciones" para Retenciones e información de pagos.
+- Se corrige la el espacio de nombres del complemento "Pagos a extranjeros" para Retenciones e información de pagos.
+- El limpiador de *Addenda* incluye también los CFDI de Retenciones e información de pagos.
+
+Se hacen los siguientes cambios al entorno de desarrollo:
+
+- En el flujo de trabajo `build` en el trabajo `tests` se usa la variable `php-version` en singular.
+- En el flujo de trabajo `coverage` en el trabajo `test-coverage` se usa mejora el título.
+- Se actualizan las herramientas de desarrollo.
+
 ## Versión 1.3.3
 
 - Se agrega *Complemento de Carta Porte 3.1* a la lista de espacio de nombres conocidos.

--- a/src/XmlDocumentCleaners/RemoveAddenda.php
+++ b/src/XmlDocumentCleaners/RemoveAddenda.php
@@ -16,6 +16,8 @@ class RemoveAddenda implements XmlDocumentCleanerInterface
     {
         $this->removeAddendas($document, 'http://www.sat.gob.mx/cfd/3');
         $this->removeAddendas($document, 'http://www.sat.gob.mx/cfd/4');
+        $this->removeAddendas($document, 'http://www.sat.gob.mx/esquemas/retencionpago/2');
+        $this->removeAddendas($document, 'http://www.sat.gob.mx/esquemas/retencionpago/1');
     }
 
     private function removeAddendas(DOMDocument $document, string $namespace): void

--- a/src/XmlDocumentCleaners/SetKnownSchemaLocations.php
+++ b/src/XmlDocumentCleaners/SetKnownSchemaLocations.php
@@ -141,6 +141,8 @@ class SetKnownSchemaLocations implements XmlDocumentCleanerInterface
         'http://www.sat.gob.mx/esquemas/retencionpago/1/dividendos#1.0'
         => 'http://www.sat.gob.mx/esquemas/retencionpago/1/dividendos/dividendos.xsd',
         'http://www.sat.gob.mx/esquemas/retencionpago/1/enajenaciondeacciones#1.0'
+        => 'http://www.sat.gob.mx/esquemas/retencionpago/1/enajenaciondeacciones/enajenaciondeacciones.xsd',
+        'http://www.sat.gob.mx/esquemas/retencionpago/1/pagosaextranjeros#1.0'
         => 'http://www.sat.gob.mx/esquemas/retencionpago/1/pagosaextranjeros/pagosaextranjeros.xsd',
         'http://www.sat.gob.mx/esquemas/retencionpago/1/fideicomisonoempresarial#1.0'
         => 'http://www.sat.gob.mx/esquemas/retencionpago/1/fideicomisonoempresarial/fideicomisonoempresarial.xsd',

--- a/tests/Features/XmlDocumentCleaners/RemoveAddendaTest.php
+++ b/tests/Features/XmlDocumentCleaners/RemoveAddendaTest.php
@@ -33,6 +33,26 @@ final class RemoveAddendaTest extends TestCase
                     </x:Comprobante>
                     XML,
             ],
+            'RET 2.0' => [
+                'http://www.sat.gob.mx/esquemas/retencionpago/2',
+                <<<XML
+                    <x:Retenciones xmlns:x="http://www.sat.gob.mx/esquemas/retencionpago/2">
+                    <x:Addenda>
+                        <o:OtherData xmlns:o="http://tempuri.org/other" foo="bar" />
+                    </x:Addenda>
+                    </x:Retenciones>
+                    XML,
+            ],
+            'RET 1.0' => [
+                'http://www.sat.gob.mx/esquemas/retencionpago/1',
+                <<<XML
+                    <x:Retenciones xmlns:x="http://www.sat.gob.mx/esquemas/retencionpago/1">
+                    <x:Addenda>
+                        <o:OtherData xmlns:o="http://tempuri.org/other" foo="bar" />
+                    </x:Addenda>
+                    </x:Retenciones>
+                    XML,
+            ],
         ];
     }
 

--- a/tests/Features/XmlStringCleaners/RepairXmlNsSchemaLocationTest.php
+++ b/tests/Features/XmlStringCleaners/RepairXmlNsSchemaLocationTest.php
@@ -34,7 +34,8 @@ class RepairXmlNsSchemaLocationTest extends TestCase
                 <<< EOT
                     <root foo="bar"
                           xsi:schemaLocation="http://localhost/a http://localhost/a.xsd"
-                          xmlns:schemaLocation="foo bar">
+                          xmlns:schemaLocation="with line terminators
+                          ">
                     </root>
                     EOT,
             ],
@@ -46,7 +47,8 @@ class RepairXmlNsSchemaLocationTest extends TestCase
                     EOT,
                 <<< EOT
                     <root foo="bar"
-                          xmlns:schemaLocation="foo bar"
+                          xmlns:schemaLocation="with line terminators
+                          "
                           xsi:schemaLocation="http://localhost/a http://localhost/a.xsd">
                     </root>
                     EOT,

--- a/tests/Traits/UseSatNsRegistryTrait.php
+++ b/tests/Traits/UseSatNsRegistryTrait.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiCleaner\Tests\Traits;
+
+use RuntimeException;
+use Throwable;
+
+trait UseSatNsRegistryTrait
+{
+    /** @var array<object{namespace: ?string, prefix: ?string, version: ?string, xsd: ?string}>|null */
+    private $satNsRegistry = null;
+
+    /** @return array<object{namespace: ?string, prefix: ?string, version: ?string, xsd: ?string}> */
+    protected function getSatNsRegistry(): array
+    {
+        if (null === $this->satNsRegistry) {
+            $this->satNsRegistry = $this->loadSatNsRegistry();
+        }
+
+        return $this->satNsRegistry;
+    }
+
+    /** @return array<object{namespace: ?string, prefix: ?string, version: ?string, xsd: ?string}> */
+    protected function loadSatNsRegistry(): array
+    {
+        // obtain the list of known locations from phpcfdi/sat-ns-registry
+        $satNsRegistryUrl = 'https://raw.githubusercontent.com/phpcfdi/sat-ns-registry/master/complementos_v1.json';
+        try {
+            /** @var array<object{namespace: ?string, prefix: ?string, version: ?string, xsd: ?string}> $registry */
+            $registry = json_decode((string) file_get_contents($satNsRegistryUrl), false, 512, JSON_THROW_ON_ERROR);
+        } catch (Throwable $exception) {
+            $message = sprintf('Unable to load SAT Namespaces Registry from %s', $satNsRegistryUrl);
+            throw new RuntimeException($message, 0, $exception);
+        }
+
+        return $registry;
+    }
+}


### PR DESCRIPTION
Se hacen las siguientes correcciones:

- Se corrige la ubicación del XSD del complemento "Enajenaciones de acciones" para Retenciones e información de pagos.
- Se corrige la el espacio de nombres del complemento "Pagos a extranjeros" para Retenciones e información de pagos.
- El limpiador de *Addenda* incluye también los CFDI de Retenciones e información de pagos.

Se hacen los siguientes cambios al entorno de desarrollo:

- En el flujo de trabajo `build` en el trabajo `tests` se usa la variable `php-version` en singular.
- En el flujo de trabajo `coverage` en el trabajo `test-coverage` se usa mejora el título.
- Se actualizan las herramientas de desarrollo.